### PR TITLE
Bz2 multistream

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
 
     install_requires=[
         'boto >= 2.0',
+        'bz2file',
     ],
 
     test_suite="smart_open.tests",

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -27,6 +27,7 @@ import os
 import subprocess
 import urlparse
 from cStringIO import StringIO
+import sys
 
 import boto.s3.key
 
@@ -282,7 +283,11 @@ def file_smart_open(fname, mode='rb'):
     _, ext = os.path.splitext(fname)
 
     if ext == '.bz2':
-        from bz2 import BZ2File
+        PY2 = sys.version_info[0] == 2
+        if PY2:
+            from bz2file import BZ2File
+        else:
+            from bz2 import BZ2File
         return make_closing(BZ2File)(fname, mode)
 
     if ext == '.gz':

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -545,8 +545,9 @@ class MultistreamsBZ2Test(unittest.TestCase):
         import bz2
 
         test_file = self.create_temp_bz2(streams=5)
-        with bz2.BZ2File(test_file) as bz2f:
-            self.assertNotEqual(bz2f.read(), self.TEXT * 5)
+        bz2f = bz2.BZ2File(test_file)
+        self.assertNotEqual(bz2f.read(), self.TEXT * 5)
+        bz2f.close()
         self.cleanup_temp_bz2(test_file)
 
     def test_file_smart_open_can_read_multistream_bz2(self):

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -538,8 +538,10 @@ class MultistreamsBZ2Test(unittest.TestCase):
             self.assertEqual(bz2f.read(), self.TEXT * 5)
         self.cleanup_temp_bz2(test_file)
 
-    @unittest.skipIf(not PY2, 'Multistream bzip is included in Python 3')
     def test_python2_stdlib_bz2_cannot_read_multistream(self):
+        # Multistream bzip is included in Python 3
+        if not PY2:
+            return
         import bz2
 
         test_file = self.create_temp_bz2(streams=5)
@@ -556,4 +558,4 @@ class MultistreamsBZ2Test(unittest.TestCase):
 
 if __name__ == '__main__':
     logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s', level=logging.DEBUG)
-    unittest.main()
+    unittest2.main()

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -558,4 +558,4 @@ class MultistreamsBZ2Test(unittest.TestCase):
 
 if __name__ == '__main__':
     logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s', level=logging.DEBUG)
-    unittest2.main()
+    unittest.main()

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -484,8 +484,8 @@ class MultistreamsBZ2Test(unittest.TestCase):
     Test that multistream bzip2 compressed files can be read.
 
     """
-    # notes these tests are derived from the Python 3.x tip bz2 tests.
 
+    # note: these tests are derived from the Python 3.x tip bz2 tests.
 
     TEXT_LINES = [
         'root:x:0:0:root:/root:/bin/bash\n',

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -9,6 +9,9 @@
 
 import unittest
 import logging
+import tempfile
+import sys
+import os
 
 import boto
 import mock
@@ -472,6 +475,83 @@ class S3IterBucketTest(unittest.TestCase):
 
         for workers in [1, 4, 8, 16, 64]:
             self.assertEqual(dict(smart_open.s3_iter_bucket(mybucket, workers=workers)), expected)
+
+
+PY2 = sys.version_info[0] == 2
+
+class MultistreamsBZ2Test(unittest.TestCase):
+    """
+    Test that multistream bzip2 compressed files can be read.
+
+    """
+    # notes these tests are derived from the Python 3.x tip bz2 tests.
+
+
+    TEXT_LINES = [
+        'root:x:0:0:root:/root:/bin/bash\n',
+        'bin:x:1:1:bin:/bin:\n',
+        'daemon:x:2:2:daemon:/sbin:\n',
+        'adm:x:3:4:adm:/var/adm:\n',
+        'lp:x:4:7:lp:/var/spool/lpd:\n',
+        'sync:x:5:0:sync:/sbin:/bin/sync\n',
+        'shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown\n',
+        'halt:x:7:0:halt:/sbin:/sbin/halt\n',
+        'mail:x:8:12:mail:/var/spool/mail:\n',
+        'news:x:9:13:news:/var/spool/news:\n',
+        'uucp:x:10:14:uucp:/var/spool/uucp:\n',
+        'operator:x:11:0:operator:/root:\n',
+        'games:x:12:100:games:/usr/games:\n',
+        'gopher:x:13:30:gopher:/usr/lib/gopher-data:\n',
+        'ftp:x:14:50:FTP User:/var/ftp:/bin/bash\n',
+        'nobody:x:65534:65534:Nobody:/home:\n',
+        'postfix:x:100:101:postfix:/var/spool/postfix:\n',
+        'niemeyer:x:500:500::/home/niemeyer:/bin/bash\n',
+        'postgres:x:101:102:PostgreSQL Server:/var/lib/pgsql:/bin/bash\n',
+        'mysql:x:102:103:MySQL server:/var/lib/mysql:/bin/bash\n',
+        'www:x:103:104::/var/www:/bin/false\n',
+        ]
+
+    TEXT = ''.join(TEXT_LINES)
+
+    DATA = 'BZh91AY&SY.\xc8N\x18\x00\x01>_\x80\x00\x10@\x02\xff\xf0\x01\x07n\x00?\xe7\xff\xe00\x01\x99\xaa\x00\xc0\x03F\x86\x8c#&\x83F\x9a\x03\x06\xa6\xd0\xa6\x93M\x0fQ\xa7\xa8\x06\x804hh\x12$\x11\xa4i4\xf14S\xd2<Q\xb5\x0fH\xd3\xd4\xdd\xd5\x87\xbb\xf8\x94\r\x8f\xafI\x12\xe1\xc9\xf8/E\x00pu\x89\x12]\xc9\xbbDL\nQ\x0e\t1\x12\xdf\xa0\xc0\x97\xac2O9\x89\x13\x94\x0e\x1c7\x0ed\x95I\x0c\xaaJ\xa4\x18L\x10\x05#\x9c\xaf\xba\xbc/\x97\x8a#C\xc8\xe1\x8cW\xf9\xe2\xd0\xd6M\xa7\x8bXa<e\x84t\xcbL\xb3\xa7\xd9\xcd\xd1\xcb\x84.\xaf\xb3\xab\xab\xad`n}\xa0lh\tE,\x8eZ\x15\x17VH>\x88\xe5\xcd9gd6\x0b\n\xe9\x9b\xd5\x8a\x99\xf7\x08.K\x8ev\xfb\xf7xw\xbb\xdf\xa1\x92\xf1\xdd|/";\xa2\xba\x9f\xd5\xb1#A\xb6\xf6\xb3o\xc9\xc5y\\\xebO\xe7\x85\x9a\xbc\xb6f8\x952\xd5\xd7"%\x89>V,\xf7\xa6z\xe2\x9f\xa3\xdf\x11\x11"\xd6E)I\xa9\x13^\xca\xf3r\xd0\x03U\x922\xf26\xec\xb6\xed\x8b\xc3U\x13\x9d\xc5\x170\xa4\xfa^\x92\xacDF\x8a\x97\xd6\x19\xfe\xdd\xb8\xbd\x1a\x9a\x19\xa3\x80ankR\x8b\xe5\xd83]\xa9\xc6\x08\x82f\xf6\xb9"6l$\xb8j@\xc0\x8a\xb0l1..\xbak\x83ls\x15\xbc\xf4\xc1\x13\xbe\xf8E\xb8\x9d\r\xa8\x9dk\x84\xd3n\xfa\xacQ\x07\xb1%y\xaav\xb4\x08\xe0z\x1b\x16\xf5\x04\xe9\xcc\xb9\x08z\x1en7.G\xfc]\xc9\x14\xe1B@\xbb!8`'
+
+    def create_temp_bz2(self, streams=1):
+        f = tempfile.NamedTemporaryFile('wb', suffix='.bz2', delete=False)
+        name = f.name
+        f.write(self.DATA * streams)
+        f.close()
+        return f.name
+
+    def cleanup_temp_bz2(self, test_file):
+        if os.path.isfile(test_file):
+            os.unlink(test_file)
+
+    def test_can_read_multistream_bz2(self):
+        if PY2:
+            # this is a backport from Python 3
+            from bz2file import BZ2File
+        else:
+            from bz2 import BZ2File
+
+        test_file = self.create_temp_bz2(streams=5)
+        with BZ2File(test_file) as bz2f:
+            self.assertEqual(bz2f.read(), self.TEXT * 5)
+        self.cleanup_temp_bz2(test_file)
+
+    @unittest.skipIf(not PY2, 'Multistream bzip is included in Python 3')
+    def test_python2_stdlib_bz2_cannot_read_multistream(self):
+        import bz2
+
+        test_file = self.create_temp_bz2(streams=5)
+        with bz2.BZ2File(test_file) as bz2f:
+            self.assertNotEqual(bz2f.read(), self.TEXT * 5)
+        self.cleanup_temp_bz2(test_file)
+
+    def test_file_smart_open_can_read_multistream_bz2(self):
+        test_file = self.create_temp_bz2(streams=5)
+        with smart_open_lib.file_smart_open(test_file) as bz2f:
+            self.assertEqual(bz2f.read(), self.TEXT * 5)
+        self.cleanup_temp_bz2(test_file)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
@piskvorky there you go: Support for multistream bzipped files in Python 2.x 
This fixes #7 