### PR TITLE
faster travis builds using their container infra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,18 @@
+sudo: false
 language: python
 notifications:
   email: false
 python:
 - "2.7"
 - "2.6"
+cache:
+  directories:
+    - $PWD/wheelhouse  # cache the dependencies
+env:
+  global:
+    - export PIP_FIND_LINKS=$PWD/wheelhouse
 install:
-- pip install mock moto
-- python setup.py install
+  - pip wheel mock moto
+  - pip install mock moto
+  - python setup.py install
 script: python setup.py test


### PR DESCRIPTION
Using containers[1] & caching the dependant packages (using wheels) so that subsequent
travis builds cache this.

As a result was able to bring down the build time to about 52 seconds[2]

[1] http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/ 
[2] https://travis-ci.org/theanalyst/smart_open/builds/49096656


