### PR TITLE
Make smart_open python 3 compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ python:
 install:
 - pip install mock moto
 - python setup.py install
-script: python setup.py test
+script: python -W ignore setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ notifications:
 python:
 - "2.7"
 - "2.6"
+- "3.3"
+- "3.4"
 install:
 - pip install mock moto
 - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
 - "3.3"
 - "3.4"
 install:
+- if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install ordereddict; fi
 - pip install mock moto
 - python setup.py install
 script: python -W ignore setup.py test

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     platforms = 'any',
 
     install_requires=[
-        'boto >= 2.0',
+        'boto >= 2.32',
         'bz2file',
     ],
 

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,8 @@ import os
 import sys
 
 # minimum required version is 2.6; py3k not supported yet
-if not ((2, 6) <= sys.version_info < (3, 0)):
-    raise ImportError("smart_open requires 2.6 <= python < 3")
+#if not ((2, 6) <= sys.version_info < (3, 0)):
+#    raise ImportError("smart_open requires 2.6 <= python < 3")
 
 
 # TODO add ez_setup?

--- a/setup.py
+++ b/setup.py
@@ -10,9 +10,9 @@
 import os
 import sys
 
-# minimum required version is 2.6; py3k not supported yet
-#if not ((2, 6) <= sys.version_info < (3, 0)):
-#    raise ImportError("smart_open requires 2.6 <= python < 3")
+# minimum required version is 2.6
+if not ((2, 6) <= sys.version_info):
+    raise ImportError("smart_open requires python >= 2.6")
 
 
 # TODO add ez_setup?

--- a/smart_open/__init__.py
+++ b/smart_open/__init__.py
@@ -1,1 +1,1 @@
-from smart_open_lib import *
+from .smart_open_lib import *


### PR DESCRIPTION
Content are always strings (or "bytes", in Python3-speak), both on input and output.