### PR TITLE
Rely on moto's install of ordereddict

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
 - "3.3"
 #- "3.4"
 install:
-- if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install ordereddict; fi
+#- if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install ordereddict; fi
 - pip install mock moto
 - python setup.py install
 script: python -W ignore setup.py test


### PR DESCRIPTION
Testing why tests sometimes fail (bc. of a moto dependency). PR not to be merged.

See spulec/moto#340 .