### PR TITLE
fixed boto and httpretty dependencies for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,10 @@ python:
 - "2.7"
 - "2.6"
 - "3.3"
-#- "3.4"
+- "3.4"
 install:
 - if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install ordereddict; fi
 - pip install mock moto
+- pip install httpretty==0.8.6
 - python setup.py install
 script: python -W ignore setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,5 @@ python:
 install:
 - if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install ordereddict; fi
 - pip install mock moto
-- pip install httpretty==0.8.6
 - python setup.py install
 script: python -W ignore setup.py test

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,8 @@ setup(
     platforms = 'any',
 
     install_requires=[
-        'boto >= 2.38',
+        'boto >= 2.32',
+        'httpretty==0.8.6',
         'bz2file',
     ],
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     platforms = 'any',
 
     install_requires=[
-        'boto >= 2.32',
+        'boto >= 2.38',
         'bz2file',
     ],
 


### PR DESCRIPTION
This PR simply summarises and repairs errors that were found in the #16 .
It was needed to switch for the newest version of boto and force travis to test with httpretty==0.8.6.