### PR TITLE
Return the key in s3_iter_bucket

### DIFF
--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -407,7 +407,7 @@ def s3_iter_bucket_process_key(key):
 def s3_iter_bucket(bucket, prefix='', accept_key=lambda key: True, key_limit=None, workers=16):
     """
     Iterate and download all S3 files under `bucket/prefix`, yielding out
-    `(key name, key content)` 2-tuples (generator).
+    `(key, key content)` 2-tuples (generator).
 
     `accept_key` is a function that accepts a key name (unicode string) and
     returns True/False, signalling whether the given key should be downloaded out or
@@ -442,7 +442,7 @@ def s3_iter_bucket(bucket, prefix='', accept_key=lambda key: True, key_limit=Non
             logger.info("yielding key #%i: %s, size %i (total %.1fMB)" %
                 (key_no, key, len(content), total_size / 1024.0 ** 2))
 
-        yield key.name, content
+        yield key, content
         key.close()
         total_size += len(content)
 

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -480,7 +480,10 @@ class S3IterBucketTest(unittest.TestCase):
         self.assertEqual(len(result), min(len(expected), 10))
 
         for workers in [1, 4, 8, 16, 64]:
-            self.assertEqual(dict(smart_open.s3_iter_bucket(mybucket, workers=workers)), expected)
+            result = {}
+            for k, c in smart_open.s3_iter_bucket(mybucket):
+                result[k.name] = c
+            self.assertEqual(result, expected)
 
 
 PY2 = sys.version_info[0] == 2

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -465,14 +465,12 @@ class S3IterBucketTest(unittest.TestCase):
         result = {}
         for k, c in smart_open.s3_iter_bucket(mybucket):
             result[k.name] = c
-        #result = dict(smart_open.s3_iter_bucket(mybucket))
         self.assertEqual(expected, result)
 
         # read some of the keys back, in parallel, using s3_iter_bucket
         result = {}
         for k, c in smart_open.s3_iter_bucket(mybucket, accept_key=lambda fname: fname.endswith('4')):
             result[k.name] = c
-        #result = dict(smart_open.s3_iter_bucket(mybucket, accept_key=lambda fname: fname.endswith('4')))
         self.assertEqual(result, dict((k, c) for k, c in expected.items() if k.endswith('4')))
 
         # read some of the keys back, in parallel, using s3_iter_bucket

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -463,14 +463,14 @@ class S3IterBucketTest(unittest.TestCase):
 
         # read all keys + their content back, in parallel, using s3_iter_bucket
         result = {}
-        for k, c in smart_open.s3_iter_bucket(mybucket)
+        for k, c in smart_open.s3_iter_bucket(mybucket):
             result[k.name] = c
         #result = dict(smart_open.s3_iter_bucket(mybucket))
         self.assertEqual(expected, result)
 
         # read some of the keys back, in parallel, using s3_iter_bucket
         result = {}
-        for k, c in smart_open.s3_iter_bucket(mybucket, accept_key=lambda fname: fname.endswith('4'))
+        for k, c in smart_open.s3_iter_bucket(mybucket, accept_key=lambda fname: fname.endswith('4')):
             result[k.name] = c
         #result = dict(smart_open.s3_iter_bucket(mybucket, accept_key=lambda fname: fname.endswith('4')))
         self.assertEqual(result, dict((k, c) for k, c in expected.items() if k.endswith('4')))

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -462,11 +462,17 @@ class S3IterBucketTest(unittest.TestCase):
                 expected[key_name] = content
 
         # read all keys + their content back, in parallel, using s3_iter_bucket
-        result = dict(smart_open.s3_iter_bucket(mybucket))
+        result = {}
+        for k, c in smart_open.s3_iter_bucket(mybucket)
+            result[k.name] = c
+        #result = dict(smart_open.s3_iter_bucket(mybucket))
         self.assertEqual(expected, result)
 
         # read some of the keys back, in parallel, using s3_iter_bucket
-        result = dict(smart_open.s3_iter_bucket(mybucket, accept_key=lambda fname: fname.endswith('4')))
+        result = {}
+        for k, c in smart_open.s3_iter_bucket(mybucket, accept_key=lambda fname: fname.endswith('4'))
+            result[k.name] = c
+        #result = dict(smart_open.s3_iter_bucket(mybucket, accept_key=lambda fname: fname.endswith('4')))
         self.assertEqual(result, dict((k, c) for k, c in expected.items() if k.endswith('4')))
 
         # read some of the keys back, in parallel, using s3_iter_bucket


### PR DESCRIPTION
Returns the entire key instead of only the key name. Breaks compatibility with older code!!!