### PR TITLE
Hdfs __iter__ implementation fix

### DIFF
--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -246,7 +246,7 @@ class HdfsOpenRead(object):
         self.parsed_uri = parsed_uri
 
     def __iter__(self):
-        hdfs = subprocess.Popen(["hadoop", "fs", "-cat", self.parsed_uri.uri_path], stdout=subprocess.PIPE)
+        hdfs = subprocess.Popen(["hdfs", "dfs", "-cat", self.parsed_uri.uri_path], stdout=subprocess.PIPE)
         return hdfs.stdout
 
     def read(self, size=None):
@@ -387,7 +387,7 @@ class S3OpenWrite(object):
         if type is not None:
             self._termination_error()
             return False
-        
+
         try:
             self.close()
         except:

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -246,7 +246,7 @@ class HdfsOpenRead(object):
         self.parsed_uri = parsed_uri
 
     def __iter__(self):
-        hdfs = subprocess.Popen(["hdfs", "dfs", "-cat", self.parsed_uri.uri_path], stdout=subprocess.PIPE)
+        hdfs = subprocess.Popen(["hdfs", "dfs", "-cat", os.path.join("/", self.parsed_uri.uri_path)], stdout=subprocess.PIPE)
         return hdfs.stdout
 
     def read(self, size=None):

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -104,6 +104,10 @@ class SmartOpenReadTest(unittest.TestCase):
         # called with the correct params?
         mock_subprocess.Popen.assert_called_with(["hdfs", "dfs", "-cat", "/tmp/test.txt"], stdout=mock_subprocess.PIPE)
 
+        # second possibility of schema
+        smart_open_object = smart_open.HdfsOpenRead(smart_open.ParseUri("hdfs://tmp/test.txt"))
+        smart_open_object.__iter__()
+        mock_subprocess.Popen.assert_called_with(["hdfs", "dfs", "-cat", "/tmp/test.txt"], stdout=mock_subprocess.PIPE)
 
     @mock.patch('smart_open.smart_open_lib.boto')
     @mock.patch('smart_open.smart_open_lib.s3_iter_lines')

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -102,7 +102,7 @@ class SmartOpenReadTest(unittest.TestCase):
         smart_open_object = smart_open.HdfsOpenRead(smart_open.ParseUri("hdfs:///tmp/test.txt"))
         smart_open_object.__iter__()
         # called with the correct params?
-        mock_subprocess.Popen.assert_called_with(["hadoop", "fs", "-cat", "/tmp/test.txt"], stdout=mock_subprocess.PIPE)
+        mock_subprocess.Popen.assert_called_with(["hdfs", "dfs", "-cat", "/tmp/test.txt"], stdout=mock_subprocess.PIPE)
 
 
     @mock.patch('smart_open.smart_open_lib.boto')


### PR DESCRIPTION
Fixed HDFS read to be able to read both `hdfs://` and `hdfs:///` (both should be equivalent and it depends on hdfs distribution)

Also fixed to use `hdfs dfs -cat` which is recommended.

Closes #24 