### PR TITLE
Implemented possibility to read directly from WebHDFS using smart_open

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ python:
 - "3.4"
 install:
 - if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install ordereddict; fi
-- pip install mock moto
+- pip install mock moto responses
 - python setup.py install
 script: python -W ignore setup.py test

--- a/README.rst
+++ b/README.rst
@@ -34,11 +34,11 @@ It is well tested (using `moto <https://github.com/spulec/moto>`_), well documen
 
   >>> # stream from HDFS
   >>> for line in smart_open.smart_open('hdfs://user/hadoop/my_file.txt'):
-  ...    print line
+  ...     print line
 
   >>> # stream from WebHDFS
   >>> for line in smart_open.smart_open('webhdfs://host:port/user/hadoop/my_file.txt'):
-  ...    print line
+  ...     print line
 
   >>> # stream content *into* S3 (write mode):
   >>> with smart_open.smart_open('s3://mybucket/mykey.txt', 'wb') as fout:

--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,10 @@ It is well tested (using `moto <https://github.com/spulec/moto>`_), well documen
   >>> for line in smart_open.smart_open('hdfs://user/hadoop/my_file.txt'):
   ...    print line
 
+  >>> # stream from WebHDFS
+  >>> for line in smart_open.smart_open('webhdfs://host:port/user/hadoop/my_file.txt'):
+  ...    print line
+
   >>> # stream content *into* S3 (write mode):
   >>> with smart_open.smart_open('s3://mybucket/mykey.txt', 'wb') as fout:
   ...     for line in ['first line', 'second line', 'third line']:

--- a/README.rst
+++ b/README.rst
@@ -90,7 +90,7 @@ Or, if you prefer to install from the `source tar.gz <http://pypi.python.org/pyp
     python setup.py test  # run unit tests
     python setup.py install
 
-To run the unit tests (optional), you'll also need to install `mock <https://pypi.python.org/pypi/mock>`_ and `moto <https://github.com/spulec/moto>`_ (``pip install mock moto``). The tests are also run automatically with `Travis CI <https://travis-ci.org/piskvorky/smart_open>`_ on every commit push & pull request.
+To run the unit tests (optional), you'll also need to install `mock <https://pypi.python.org/pypi/mock>`_ , `moto <https://github.com/spulec/moto>`_ and `responses <https://github.com/getsentry/responses>` (``pip install mock moto responses``). The tests are also run automatically with `Travis CI <https://travis-ci.org/piskvorky/smart_open>`_ on every commit push & pull request.
 
 Todo
 ----

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -145,8 +145,7 @@ class ParseUri(object):
 
         if self.scheme == "hdfs":
             self.uri_path = parsed_uri.netloc + parsed_uri.path
-            if self.uri_path[0] != "/":
-                self.uri_path = "/" + self.uri_path
+            self.uri_path = "/" + self.uri_path.lstrip("/")
 
             if not self.uri_path:
                 raise RuntimeError("invalid HDFS URI: %s" % uri)

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -263,7 +263,7 @@ class HdfsOpenRead(object):
         self.parsed_uri = parsed_uri
 
     def __iter__(self):
-        hdfs = subprocess.Popen(["hdfs", "dfs", "-cat", os.path.join("/", self.parsed_uri.uri_path)], stdout=subprocess.PIPE)
+        hdfs = subprocess.Popen(["hdfs", "dfs", "-cat", "/" + self.parsed_uri.uri_path], stdout=subprocess.PIPE)
         return hdfs.stdout
 
     def read(self, size=None):
@@ -292,7 +292,7 @@ class WebHdfsOpenRead(object):
 
     def __iter__(self):
         payload = {"op": "OPEN"}
-        response = requests.get(os.path.join("http://", self.parsed_uri.uri_path), params=payload, stream=True)
+        response = requests.get("http://" + self.parsed_uri.uri_path, params=payload, stream=True)
         return response.iter_lines()
 
     def read(self, size=None):

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -230,12 +230,6 @@ class S3OpenRead(object):
             size = 0
         return self.read_key.read(size)
 
-    def readline(self):
-        """
-        Read line of the file from the key
-        """
-        return next(self.line_generator)
-
     def seek(self, offset, whence=0):
         """
         Seek to the specified position.

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -123,7 +123,7 @@ class ParseUri(object):
       * s3://my_key:my_secret@my_bucket/my_key
       * hdfs:///path/file
       * hdfs://path/file
-      * webhdfs://host:port/path
+      * webhdfs://host:port/path/file
       * ./local/path/file
       * ./local/path/file.gz
       * file:///home/user/file

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -145,6 +145,8 @@ class ParseUri(object):
 
         if self.scheme == "hdfs":
             self.uri_path = parsed_uri.netloc + parsed_uri.path
+            if self.uri_path[0] != "/":
+                self.uri_path = "/" + self.uri_path
 
             if not self.uri_path:
                 raise RuntimeError("invalid HDFS URI: %s" % uri)
@@ -263,7 +265,7 @@ class HdfsOpenRead(object):
         self.parsed_uri = parsed_uri
 
     def __iter__(self):
-        hdfs = subprocess.Popen(["hdfs", "dfs", "-cat", "/" + self.parsed_uri.uri_path], stdout=subprocess.PIPE)
+        hdfs = subprocess.Popen(["hdfs", "dfs", "-cat", self.parsed_uri.uri_path], stdout=subprocess.PIPE)
         return hdfs.stdout
 
     def read(self, size=None):

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -77,6 +77,12 @@ class ParseUriTest(unittest.TestCase):
         # incorrect uri - only one '@' in uri is allowed
         self.assertRaises(RuntimeError, smart_open.ParseUri, "s3://access_id@access_secret@mybucket/mykey")
 
+    def test_webhdfs_uri(self):
+        """Do webhdfs USIs parse correctly"""
+        parsed_uri = smart_open.ParseUri("webhdfs://host:port/path/file")
+        self.assertEqual(parsed_uri.scheme, "webhdfs")
+        self.assertEqual(parsed_uri.uri_path, "host:port/webhdfs/v1/path/file")
+
 
 class SmartOpenReadTest(unittest.TestCase):
     """

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -124,6 +124,13 @@ class SmartOpenReadTest(unittest.TestCase):
         self.assertEqual(iterator.next(), "line1")
         self.assertEqual(iterator.next(), "line2")
 
+    @responses.activate
+    def test_webhdfs_read(self):
+        """Does webhdfs read method work correctly"""
+        responses.add(responses.GET, "http://127.0.0.1:8440/webhdfs/v1/path/file", body='line1\nline2')
+        smart_open_object = smart_open.WebHdfsOpenRead(smart_open.ParseUri("webhdfs://127.0.0.1:8440/path/file"))
+        self.assertEqual(smart_open_object.read(), "line1\nline2")
+
     @mock.patch('smart_open.smart_open_lib.boto')
     @mock.patch('smart_open.smart_open_lib.s3_iter_lines')
     def test_s3_boto(self, mock_s3_iter_lines, mock_boto):

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -16,7 +16,6 @@ import os
 import boto
 import mock
 from moto import mock_s3
-import requests
 import responses
 
 import smart_open
@@ -116,10 +115,11 @@ class SmartOpenReadTest(unittest.TestCase):
         smart_open_object.__iter__()
         mock_subprocess.Popen.assert_called_with(["hdfs", "dfs", "-cat", "/tmp/test.txt"], stdout=mock_subprocess.PIPE)
 
-    def test_webhdfs(self, mock_get):
+    @responses.activate
+    def test_webhdfs(self):
         """Is webhdfs line iterator called correctly"""
-        responses.add(responses.GET, "http://host:port/webhdfs/v1/path/file", body='abc\n123')
-        smart_open_object = smart_open.WebHdfsOpenRead(smart_open.ParseUri("webhdfs://host:port/path/file"))
+        responses.add(responses.GET, "http://127.0.0.1:8440/webhdfs/v1/path/file", body='line1\nline2')
+        smart_open_object = smart_open.WebHdfsOpenRead(smart_open.ParseUri("webhdfs://127.0.0.1:8440/path/file"))
         iterator = iter(smart_open_object)
         self.assertEqual(iterator.next(), "line1")
         self.assertEqual(iterator.next(), "line2")

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -121,15 +121,15 @@ class SmartOpenReadTest(unittest.TestCase):
         responses.add(responses.GET, "http://127.0.0.1:8440/webhdfs/v1/path/file", body='line1\nline2')
         smart_open_object = smart_open.WebHdfsOpenRead(smart_open.ParseUri("webhdfs://127.0.0.1:8440/path/file"))
         iterator = iter(smart_open_object)
-        self.assertEqual(iterator.next(), "line1")
-        self.assertEqual(iterator.next(), "line2")
+        self.assertEqual(next(iterator).decode("utf-8"), "line1")
+        self.assertEqual(next(iterator).decode("utf-8"), "line2")
 
     @responses.activate
     def test_webhdfs_read(self):
         """Does webhdfs read method work correctly"""
         responses.add(responses.GET, "http://127.0.0.1:8440/webhdfs/v1/path/file", body='line1\nline2')
         smart_open_object = smart_open.WebHdfsOpenRead(smart_open.ParseUri("webhdfs://127.0.0.1:8440/path/file"))
-        self.assertEqual(smart_open_object.read(), "line1\nline2")
+        self.assertEqual(smart_open_object.read().decode("utf-8"), "line1\nline2")
 
     @mock.patch('smart_open.smart_open_lib.boto')
     @mock.patch('smart_open.smart_open_lib.s3_iter_lines')

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -79,7 +79,7 @@ class ParseUriTest(unittest.TestCase):
         self.assertRaises(RuntimeError, smart_open.ParseUri, "s3://access_id@access_secret@mybucket/mykey")
 
     def test_webhdfs_uri(self):
-        """Do webhdfs USIs parse correctly"""
+        """Do webhdfs URIs parse correctly"""
         parsed_uri = smart_open.ParseUri("webhdfs://host:port/path/file")
         self.assertEqual(parsed_uri.scheme, "webhdfs")
         self.assertEqual(parsed_uri.uri_path, "host:port/webhdfs/v1/path/file")


### PR DESCRIPTION
This PR partially solves the issue https://github.com/piskvorky/smart_open/issues/23. It implements reading from WebHDFS based on API described at https://hadoop.apache.org/docs/r1.0.4/webhdfs.html.

For reading from WebHDFS you can use:
`webhdfs://host:port/path/file`

**NOTE:**
 - It does not support kerberos authentication yet (so it only works for WebHDFS that is not secured)
 - Please do not merge yet, I'll try to implement read and seek methods in this PR soon as well. 