### PR TITLE
make smart_open a no-op if passed a file-like

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         'boto >= 2.32',
         'httpretty==0.8.6',
         'bz2file',
+        'requests',
     ],
 
     test_suite="smart_open.tests",

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -80,6 +80,10 @@ def smart_open(uri, mode="rb", **kw):
       ...    fout.write("good bye!\n")
 
     """
+    # simply pass-through if already a file-like
+    if not isinstance(uri, six.string_types) and hasattr(uri, 'read'):
+        return uri
+
     # this method just routes the request to classes handling the specific storage
     # schemes, depending on the URI protocol in `uri`
     parsed_uri = ParseUri(uri)


### PR DESCRIPTION
If rather than a string URI/path, `smart_open()` receives an object with a `read` attribute, pass it through: it's arguably already 'open'.