### PR TITLE
Upgraded httpretty version; fixing #40

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
 
     install_requires=[
         'boto >= 2.32',
-        'httpretty==0.8.6',
+        'httpretty>=0.8.8',
         'bz2file',
         'requests',
     ],


### PR DESCRIPTION
httpretty==0.8.6 cannot be installed with `LANG=C` and consequently neither can be `smart_open` (and `gensim`). This pull relaxes the version constrains since the bug was fixed in 0.8.8.