### PR TITLE
First attempt to implement reading via SSH/SCP

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ smart_open -- utils for streaming large files
 What?
 =====
 
-``smart_open`` is a Python 2 & Python 3 library for **efficient streaming of very large files** from/to S3, HDFS, WebHDFS or local (compressed) files.
+``smart_open`` is a Python 2 & Python 3 library for **efficient streaming of very large files** from/to S3, HDFS, WebHDFS, SSH/SCP or local (compressed) files.
 It is well tested (using `moto <https://github.com/spulec/moto>`_), well documented and sports a simple, Pythonic API:
 
 .. code-block:: python
@@ -31,6 +31,10 @@ It is well tested (using `moto <https://github.com/spulec/moto>`_), well documen
   ...         print line
   ...     fin.seek(0)  # seek to the beginning
   ...     print fin.read(1000)  # read 1000 bytes
+
+  >>> # stream from SSH/SCP (NOTE: you haev to have set your public ssh key on the remote machine)
+  >>> for line in smart_open.smart_open('ssh://ubuntu@ip_address:/some/path/lines.txt'):
+  ...     print line
 
   >>> # stream from HDFS
   >>> for line in smart_open.smart_open('hdfs://user/hadoop/my_file.txt'):

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -287,7 +287,7 @@ class SSHOpenRead(object):
         self.parsed_uri = parsed_uri
 
     def __iter__(self):
-        ssh = subprocess.Popen("ssh " + self.parsed_uri.netloc + " 'cat " + self.parsed_uri.uri_path + "'",
+        ssh = subprocess.Popen("ssh -o StrictHostKeyChecking=no " + self.parsed_uri.netloc + " 'cat " + self.parsed_uri.uri_path + "'",
             stdout=subprocess.PIPE, shell=True)
         return ssh.stdout
 

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -129,7 +129,7 @@ class SmartOpenReadTest(unittest.TestCase):
         smart_open_object = smart_open.SSHOpenRead(smart_open.ParseUri("ssh://ubuntu@ip_address:/some/path/lines.txt"))
         smart_open_object.__iter__()
         # called with the correct params?
-        mock_subprocess.Popen.assert_called_with("ssh ubuntu@ip_address 'cat /some/path/lines.txt'", stdout=mock_subprocess.PIPE, shell=True)
+        mock_subprocess.Popen.assert_called_with("ssh -o StrictHostKeyChecking=no ubuntu@ip_address 'cat /some/path/lines.txt'", stdout=mock_subprocess.PIPE, shell=True)
 
     @responses.activate
     def test_webhdfs(self):


### PR DESCRIPTION
Goal of this PR is to add the functionality of reading files via SSH/SCP from remote machines part of what was discussed in the issue #36 .

PLEASE DO NOT MERGE YET:
TODO:

- [x] ~~implement tests~~
- [x] update README.rst

What should be discussed:
- authentication (should we care of authentication or can we estimate that everybody has copied SSH keys to the machine before using smart_open at least for the beginning)