### PR TITLE
Set key to empty when S3OpenWrite closed writing any data

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+* HEAD
+
+  - Write an empty key to S3 even if nothing is written to S3OpenWrite (PR #61, @petedmarsh)
+
 * 1.3.2, 3rd January 2016
 
   - Bug fix release to enable 'wb+' file mode (PR #50)

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -492,9 +492,11 @@ class S3OpenWrite(object):
         else:
             # AWS complains with "The XML you provided was not well-formed or did not validate against our published schema"
             # when the input is completely empty => abort the upload, no file created
-            # TODO: or create the empty file some other way?
             logger.info("empty input, ignoring multipart upload")
             self.outkey.bucket.cancel_multipart_upload(self.mp.key_name, self.mp.id)
+            # So, instead, create an empty file like this
+            logger.info("setting an empty value for the key")
+            self.outkey.set_contents_from_string('')
 
     def __enter__(self):
         return self

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -433,6 +433,27 @@ class S3OpenWriteTest(unittest.TestCase):
         self.assertEqual(output, [b"testtest\n", b"test"])
 
 
+    @mock_s3
+    def test_write_04(self):
+        """Does writing no data cause key with an empty value to be created?"""
+        # fake connection, bucket and key
+        conn = boto.connect_s3()
+        conn.create_bucket("mybucket")
+        mybucket = conn.get_bucket("mybucket")
+        mykey = boto.s3.key.Key()
+        mykey.name = "testkey"
+        mykey.bucket = mybucket
+
+        smart_open_write = smart_open.S3OpenWrite(mykey)
+        with smart_open_write as fin:
+            pass
+
+        # read back the same key and check its content
+        output = list(smart_open.smart_open("s3://mybucket/testkey"))
+
+        self.assertEqual(output, [])
+
+
 class WebHdfsWriteTest(unittest.TestCase):
     """
     Test writing into webhdfs files.


### PR DESCRIPTION
S3 does not support zero-content multi-part file uploads, i.e. if you try to
multi-part upload no data then you'll get an error. This meant that if, for
some reason, you opened an S3 key for writing but actually didn't write to it
at all then nothing would be written to that key.

This changes S3OpenWrite to fallback to set_contents_from_string to set a key
to have an empty (zero byte) in this situation.