### PR TITLE
Passing extra parameters when writing to S3 keys (#35)

### DIFF
--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -124,7 +124,7 @@ def smart_open(uri, mode="rb", **kw):
                 key = bucket.get_key(parsed_uri.key_id)
                 if key is None:
                     raise KeyError(parsed_uri.key_id)
-                return S3OpenRead(key, **kw)
+                return S3OpenRead(key)
             elif mode in ('w', 'wb'):
                 key = bucket.get_key(parsed_uri.key_id, validate=False)
                 if key is None:
@@ -152,7 +152,7 @@ def smart_open(uri, mode="rb", **kw):
         if mode in ('r', 'rb'):
             return S3OpenRead(uri)
         elif mode in ('w', 'wb'):
-            return S3OpenWrite(uri)
+            return S3OpenWrite(uri, **kw)
     elif hasattr(uri, 'read'):
         # simply pass-through if already a file-like
         return uri


### PR DESCRIPTION
Passing along extra parameters to `initiate_multipart_upload` when
writing S3 keys directly. This is necessary, for example, to allow
server-side encryption to be used through the `encrypt_key` parameter.