### PR TITLE
Remove explicit version pins

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,9 +45,9 @@ setup(
 
     install_requires=[
         'boto >= 2.32',
-        'httpretty==0.8.10',
+        'httpretty >= 0.8.10',
         'bz2file',
-        'requests<=2.8.1',
+        'requests',
     ],
 
     test_suite="smart_open.tests",


### PR DESCRIPTION
It's generally good practice to be as tolerant as possible in libs like this. Unless there is a very good reason not to, don't put pins on dependencies. I'm assuming this uses specific httpretty>=0.8.10 features and boto>=2.32 features. Also, it's good practice to only ever use `>=`, and never `<=` (as this will prevent these dependencies from being upgraded).