### PR TITLE
setup.py: Removed httpretty dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ setup(
         'boto >= 2.32',
         'bz2file',
         'requests',
-        'httpretty == 0.8.10',
     ],
 
     test_suite="smart_open.tests",


### PR DESCRIPTION
Checking whether `httpretty` is really required? When looking at code I could not find any imports of `httpretty`. The file `test_smart_open.py` uses `mock` — an other library for mocking. This also explain, why some versions broke tests. So, I suppose, that `httpretty` is here only due to some legacy reasons and can therefore be removed.

@tmylk can you double check this? I think we can remove `httpretty` from dependency list and thereby also resolve some issues.