### PR TITLE
Allow optional S3 host in smart_open kargs.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+* 1.3.4,
+
+  - Allow passing boto `host` to smart_open (PR #71, @robcowie)
+
 * 1.3.3,  
 
   - Allow passing boto `profile_name` to smart_open (PR #68, @robcowie)

--- a/README.rst
+++ b/README.rst
@@ -81,6 +81,19 @@ For more info (S3 credentials in URI, minimum S3 part size...) and full method s
   >>> import smart_open
   >>> help(smart_open.smart_open_lib)
 
+S3-Specific Options
+-------------------
+
+There are a few optional keyword arguments that are useful only for S3 access.
+
+.. code-block:: python
+
+  >>> smart_open.smart_open('s3://', host='s3.amazonaws.com')
+  >>> smart_open.smart_open('s3://', profile_name='my-profile')
+
+
+These are both passed to `boto.s3_connect()` as keyword arguments.
+
 Why?
 ----
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def read(fname):
 
 setup(
     name = 'smart_open',
-    version = '1.3.2',
+    version = '1.3.3',
     description = 'Utils for streaming large files (S3, HDFS, gzip, bz2...)',
     long_description = read('README.rst'),
 

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -118,10 +118,16 @@ def smart_open(uri, mode="rb", **kw):
             # compression, if any, is determined by the filename extension (.gz, .bz2)
             return file_smart_open(parsed_uri.uri_path, mode)
         elif parsed_uri.scheme in ("s3", "s3n"):
+            # Get an S3 host. It is required for sigv4 operations.
+            host = kw.pop('host', None)
+            if not host:
+                host = boto.config.get('s3', 'host', 's3.amazonaws.com')
+
             # For credential order of precedence see
             # http://boto.cloudhackers.com/en/latest/boto_config_tut.html#credentials
             s3_connection = boto.connect_s3(
                 aws_access_key_id=parsed_uri.access_id,
+                host=host,
                 aws_secret_access_key=parsed_uri.access_secret,
                 profile_name=kw.pop('profile_name', None))
 


### PR DESCRIPTION
Boto requires a `host` argument for sigv4 api calls. If not provided it raises a `boto.s3.connection.HostRequiredError` exception.

To solve this a `host` keyword argument is now supported and is passed to boto when creating the S3 connection. If it is not supplied, a default is derived from boto config.

```python
smart_open('s3://bucket/prefix/')
smart_open('s3://bucket/prefix/', host='s3.amazonaws.com')
smart_open('s3://bucket/prefix/', host='s3.eu-central-1.amazonaws.com')
```