### PR TITLE
ssh/scp/sftp: enable pipelining of write operations

### DIFF
--- a/smart_open/ssh.py
+++ b/smart_open/ssh.py
@@ -107,6 +107,7 @@ def open(path, mode='r', host=None, user=None, password=None, port=DEFAULT_PORT,
     conn = _connect(host, user, port, password, transport_params)
     sftp_client = conn.get_transport().open_sftp_client()
     file_obj = sftp_client.open(path, mode)
-    if mode.startswith("w"):
+    is_pipelining_enabled = transport_params.get('write_pipelining', True)
+    if is_pipelining_enabled and mode.startswith("w"):
         file_obj.set_pipelined(True)
     return file_obj

--- a/smart_open/ssh.py
+++ b/smart_open/ssh.py
@@ -106,4 +106,7 @@ def open(path, mode='r', host=None, user=None, password=None, port=DEFAULT_PORT,
 
     conn = _connect(host, user, port, password, transport_params)
     sftp_client = conn.get_transport().open_sftp_client()
-    return sftp_client.open(path, mode)
+    file_obj = sftp_client.open(path, mode)
+    if mode.startswith("w"):
+        file_obj.set_pipelined(True)
+    return file_obj

--- a/smart_open/tests/test_ssh.py
+++ b/smart_open/tests/test_ssh.py
@@ -41,6 +41,25 @@ class SSHOpen(unittest.TestCase):
         )
         mock_connect.assert_called_with("some-host", 22, username="ubuntu", password="pwd")
 
+    @mock_ssh
+    def test_write_pipelining_for_reading(self, mock_connect, get_transp_mock):
+        smart_open.open("ssh://user:pass@some-host/", "r")
+        get_transp_mock().open_sftp_client().open().set_pipelined.assert_not_called()
+
+    @mock_ssh
+    def test_write_pipelining(self, mock_connect, get_transp_mock):
+        smart_open.open("ssh://user:pass@some-host/", "w")
+        get_transp_mock().open_sftp_client().open().set_pipelined.assert_called()
+
+    @mock_ssh
+    def test_disable_write_pipelining(self, mock_connect, get_transp_mock):
+        smart_open.open(
+            "ssh://user:pass@some-host/",
+            "w",
+            transport_params={"write_pipelining": False}
+        )
+        get_transp_mock().open_sftp_client().open().set_pipelined.assert_not_called()
+
 
 if __name__ == "__main__":
     logging.basicConfig(format="%(asctime)s : %(levelname)s : %(message)s", level=logging.DEBUG)


### PR DESCRIPTION
#### Turn on pipelining of write operations for ssh/scp/sftp 

#### Motivation

It significantly speeds up writes. From paramiko docs:

> When pipelining is on, paramiko won’t wait for the server response after each write operation. Instead, they’re collected as they come in. At the first non-write operation (including close), all remaining server responses are collected. This means that if there was an error with one of your later writes, an exception might be thrown from within close instead of write.

Popular sftp client library **pysftp** enables pipelining for put operations.

Result of simple [benchmark](https://gist.github.com/mrk-its/04c3f0430ac4e548dfecba6c3a8a41be)

pipelining disabled:

> Total time: 33.55 seconds, sent: 2621440 bytes, speed: 76 kbytes/sec


pipelining enabled:

> Total time: 3.58 seconds, sent: 2621440 bytes, speed: 714 kbytes/sec
