### PR TITLE
Fix s3.iter_bucket failure when botocore_session passed in

### DIFF
--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -686,6 +686,34 @@ class IterBucketTest(unittest.TestCase):
         condition=sys.platform == 'darwin',
         reason="MacOS uses spawn rather than fork for multiprocessing",
     )
+    def test_iter_bucket_passed_in_session_multiprocessing_true(self):
+        populate_bucket()
+        smart_open.concurrency._MULTIPROCESSING = True
+        my_session = botocore.session.Session()
+        results = list(smart_open.s3.iter_bucket(bucket_name=BUCKET_NAME,
+                                      botocore_session=my_session,
+                                      workers=1))
+        self.assertEqual(len(results), 10)
+
+    @pytest.mark.skipif(condition=sys.platform == 'win32', reason="does not run on windows")
+    @pytest.mark.xfail(
+        condition=sys.platform == 'darwin',
+        reason="MacOS uses spawn rather than fork for multiprocessing",
+    )
+    def test_iter_bucket_passed_in_session_multiprocessing_false(self):
+        populate_bucket()
+        smart_open.concurrency._MULTIPROCESSING = False
+        my_session = botocore.session.Session()
+        results = list(smart_open.s3.iter_bucket(bucket_name=BUCKET_NAME,
+                                      botocore_session=my_session,
+                                      workers=1))
+        self.assertEqual(len(results), 10)
+
+    @pytest.mark.skipif(condition=sys.platform == 'win32', reason="does not run on windows")
+    @pytest.mark.xfail(
+        condition=sys.platform == 'darwin',
+        reason="MacOS uses spawn rather than fork for multiprocessing",
+    )
     def test_iter_bucket_404(self):
         populate_bucket()
 


### PR DESCRIPTION
#### Motivation
Fixes #670 

As shown by @SootyOwl, when a user declares their own `botocore_session` object and passes it into `s3.iter_bucket`, one of two errors occur:
1. With **smart_open.concurrency._MULTIPROCESSING = True**:
   `AttributeError: Can't pickle local object 'lazy_call.<locals>._handler`
2. With **smart_open.concurrency._MULTIPROCESSING = False**:
   `RuntimeError: Cannot inject class attribute "upload_file", attribute already exists in class dict.`

As explained [here](https://stackoverflow.com/questions/52265120/python-multiprocessing-pool-attributeerror), the reason the first error occurs is that the multiprocessing module performs pickling on objects and requires those objects to be global, not local.

As explained in the original raised issue, the reason the second error occurs is that `_list_bucket` and `_download_key` both creates `boto3.session.Session` objects out of the passed in `botocore_session`, which is not allowed by the boto3 library.

The proposed changes address both issues by creating a global session object within `iter_bucket` that `_list_bucket` and `_download_key` can access.
 
#### Tests
All existing tests related to `iter_bucket` within `s3.py` pass. I also added two new tests: `test_iter_bucket_passed_in_session_multiprocessing_false` and `test_iter_bucket_passed_in_session_multiprocessing_true`. These test the two previously failing situations.