### PR TITLE
Fix #684 Abort S3 MultipartUpload if exception is raised

### DIFF
--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -554,7 +554,6 @@ class MultipartWriterTest(unittest.TestCase):
 
             assert actual == contents
 
-
     def test_write_gz_with_error(self):
         """Does s3 multipart chunking work correctly if exception is raised for compression file?"""
 


### PR DESCRIPTION
#### Motivation

- Fixes #684
AWS Supports multipart upload of a file. I big file split by chunks uploaded one by one and on S3 concatenated again.
In our case, if an exception is raised while processing one of the parts we have to abort uploading to avoid corrupted file creation.

#### Tests

`test_write_gz_with_error`
