### PR TITLE
Make s3u protocol have the intended non-SSL behaviour

### DIFF
--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -88,6 +88,10 @@ def parse_uri(uri_as_string):
     #
     split_uri = smart_open.utils.safe_urlsplit(uri_as_string)
     assert split_uri.scheme in SCHEMES
+    if split_uri.scheme == "s3u":
+        ssl_mode = ""
+    else:
+        ssl_mode = "s"
 
     port = DEFAULT_PORT
     host = DEFAULT_HOST
@@ -130,6 +134,7 @@ def parse_uri(uri_as_string):
         ordinary_calling_format=ordinary_calling_format,
         access_id=access_id,
         access_secret=access_secret,
+        ssl_mode=ssl_mode,
     )
 
 
@@ -184,7 +189,7 @@ def _consolidate_params(uri, transport_params):
         )
         uri.update(host=None)
     elif uri['host'] != DEFAULT_HOST:
-        inject(endpoint_url='https://%(host)s:%(port)d' % uri)
+        inject(endpoint_url='http%(ssl_mode)s://%(host)s:%(port)d' % uri)
         uri.update(host=None)
 
     return uri, transport_params

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -88,10 +88,6 @@ def parse_uri(uri_as_string):
     #
     split_uri = smart_open.utils.safe_urlsplit(uri_as_string)
     assert split_uri.scheme in SCHEMES
-    if split_uri.scheme == "s3u":
-        ssl_mode = ""
-    else:
-        ssl_mode = "s"
 
     port = DEFAULT_PORT
     host = DEFAULT_HOST
@@ -134,7 +130,6 @@ def parse_uri(uri_as_string):
         ordinary_calling_format=ordinary_calling_format,
         access_id=access_id,
         access_secret=access_secret,
-        ssl_mode=ssl_mode,
     )
 
 
@@ -189,7 +184,11 @@ def _consolidate_params(uri, transport_params):
         )
         uri.update(host=None)
     elif uri['host'] != DEFAULT_HOST:
-        inject(endpoint_url='http%(ssl_mode)s://%(host)s:%(port)d' % uri)
+        if uri['scheme'] == 's3u':
+            scheme = 'http'
+        else:
+            scheme = 'https'
+        inject(endpoint_url=scheme + '://%(host)s:%(port)d' % uri)
         uri.update(host=None)
 
     return uri, transport_params


### PR DESCRIPTION
Currently https is hardcoded in when s3* protocol is used. However in the documentation it states s3u is the non-SSL version, but this appears unimplemented.

When s3u is used, use http rather than https.

#### Tests

Could a maintainer please advise how (if?) a test should be written for this change.
I don't believe vanilla AWS S3 supports unsecured http.

I am not able to run pytest on this PR as I don't have access to an AWS S3 bucket (I am making this change so I can use smart_open with my minio installation).

#### Checklist

Before you create the PR, please make sure you have:

- [x] Picked a concise, informative and complete title
- [x] Clearly explained the motivation behind the PR
- [x] Linked to any existing issues that your PR will be solving
- [ ] Included tests for any new functionality
- [ ] Checked that all unit tests pass