### PR TITLE
Retry finalizing multipart s3 upload

### DIFF
--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -834,13 +834,7 @@ multipart upload may fail")
                 UploadId=self._upload_id,
                 MultipartUpload={'Parts': self._parts},
             )
-            _retry_if_failed(
-                partial, 
-                exceptions=(
-                    botocore.exceptions.EndpointConnectionError, 
-                    botocore.errorfactory.NoSuchUpload,
-                ),
-            )
+            _retry_if_failed(partial)
             logger.debug('%s: completed multipart upload', self)
         elif self._upload_id:
             #
@@ -1120,22 +1114,40 @@ def _retry_if_failed(
         partial,
         attempts=_UPLOAD_ATTEMPTS,
         sleep_seconds=_SLEEP_SECONDS,
-        exceptions=None):
+        exceptions=None,  # Dict[Exception, str]
+        client_error_codes=None):  # Dict[str, str]
     if exceptions is None:
-        exceptions = (botocore.exceptions.EndpointConnectionError, )
+        exceptions = {
+            botocore.exceptions.EndpointConnectionError: 'Unable to connect to the endpoint. Check your network connection.',
+        }
+    if client_error_codes is None:
+        client_error_codes = {'NoSuchUpload': 'Server-side flaky error (NoSuchUpload).'}
     for attempt in range(attempts):
         try:
             return partial()
-        except exceptions:
+        except tuple(exceptions) as exc:
+            msg = exceptions[type(exc)]
             logger.critical(
-                'Unable to connect to the endpoint. Check your network connection. '
-                'Sleeping and retrying %d more times '
-                'before giving up.' % (attempts - attempt - 1)
+                '%s Sleeping and retrying %d more times before giving up.',
+                msg,
+                attempts - attempt - 1,
             )
             time.sleep(sleep_seconds)
+        except botocore.exceptions.ClientError as exc:
+            error_code = exc['Error']['Code']
+            if error_code not in client_error_codes:
+                raise
+            msg = client_error_codes[error_code]
+            logger.critical(
+                '%s Sleeping and retrying %d more times before giving up.',
+                msg,
+                attempts - attempt - 1,
+            )
+            time.sleep(sleep_seconds)
+            
     else:
-        logger.critical('Unable to connect to the endpoint. Giving up.')
-        raise IOError('Unable to connect to the endpoint after %d attempts' % attempts)
+        logger.critical('%s Giving up.', msg)
+        raise IOError('%s failed after %d attempts', partial.func.__name__, attempts)
 
 
 def _accept_all(key):

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -834,7 +834,13 @@ multipart upload may fail")
                 UploadId=self._upload_id,
                 MultipartUpload={'Parts': self._parts},
             )
-            _retry_if_failed(partial)
+            _retry_if_failed(
+                partial, 
+                exceptions=(
+                    botocore.exceptions.EndpointConnectionError, 
+                    botocore.errorfactory.NoSuchUpload,
+                ),
+            )
             logger.debug('%s: completed multipart upload', self)
         elif self._upload_id:
             #

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -1118,7 +1118,9 @@ def _retry_if_failed(
         client_error_codes=None):  # Dict[str, str]
     if exceptions is None:
         exceptions = {
-            botocore.exceptions.EndpointConnectionError: 'Unable to connect to the endpoint. Check your network connection.',
+            botocore.exceptions.EndpointConnectionError: (
+                'Unable to connect to the endpoint. Check your network connection.'
+            ),
         }
     if client_error_codes is None:
         client_error_codes = {'NoSuchUpload': 'Server-side flaky error (NoSuchUpload).'}
@@ -1144,7 +1146,6 @@ def _retry_if_failed(
                 attempts - attempt - 1,
             )
             time.sleep(sleep_seconds)
-            
     else:
         logger.critical('%s Giving up.', msg)
         raise IOError('%s failed after %d attempts', partial.func.__name__, attempts)

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -1148,7 +1148,7 @@ def _retry_if_failed(
             time.sleep(sleep_seconds)
     else:
         logger.critical('%s Giving up.', msg)
-        raise IOError('%s failed after %d attempts', partial.func.__name__, attempts)
+        raise IOError('%s failed after %d attempts', partial.func, attempts)
 
 
 def _accept_all(key):

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -1136,7 +1136,7 @@ def _retry_if_failed(
             )
             time.sleep(sleep_seconds)
         except botocore.exceptions.ClientError as err:
-            error_code =  err.response['Error'].get('Code')
+            error_code = err.response['Error'].get('Code')
             if error_code not in client_error_codes:
                 raise
             msg = client_error_codes[error_code]

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -1127,16 +1127,16 @@ def _retry_if_failed(
     for attempt in range(attempts):
         try:
             return partial()
-        except tuple(exceptions) as exc:
-            msg = exceptions[type(exc)]
+        except tuple(exceptions) as err:
+            msg = exceptions[type(err)]
             logger.critical(
                 '%s Sleeping and retrying %d more times before giving up.',
                 msg,
                 attempts - attempt - 1,
             )
             time.sleep(sleep_seconds)
-        except botocore.exceptions.ClientError as exc:
-            error_code = exc['Error']['Code']
+        except botocore.exceptions.ClientError as err:
+            error_code =  err.response['Error'].get('Code')
             if error_code not in client_error_codes:
                 raise
             msg = client_error_codes[error_code]

--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -21,6 +21,7 @@ import sys
 import boto3
 import botocore.client
 import botocore.endpoint
+import botocore.exceptions
 import moto
 import pytest
 
@@ -958,6 +959,17 @@ class RetryIfFailedTest(unittest.TestCase):
 
         with self.assertRaises(IOError):
             smart_open.s3._retry_if_failed(partial, attempts=3, sleep_seconds=0, exceptions=exceptions)
+
+        self.assertEqual(partial.call_count, 3)
+
+        partial = mock.Mock(
+            side_effect=botocore.exceptions.ClientError(
+                {'Error': {'Code': 'NoSuchUpload'}}, 'NoSuchUpload'
+            )
+        )
+
+        with self.assertRaises(IOError):
+            smart_open.s3._retry_if_failed(partial, attempts=3, sleep_seconds=0)
 
         self.assertEqual(partial.call_count, 3)
 

--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -22,7 +22,6 @@ import boto3
 import botocore.client
 import botocore.endpoint
 import botocore.exceptions
-import moto
 import pytest
 
 # See https://github.com/piskvorky/smart_open/issues/800

--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -971,7 +971,6 @@ class RetryIfFailedTest(unittest.TestCase):
             self.retry._do(partial)
         self.assertEqual(partial.call_count, 3)
 
-
     def test_failure_client_error(self):
         partial = mock.Mock(
             side_effect=botocore.exceptions.ClientError(

--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -954,7 +954,7 @@ class RetryIfFailedTest(unittest.TestCase):
 
     def test_failure(self):
         partial = mock.Mock(side_effect=ValueError)
-        exceptions = (ValueError, )
+        exceptions = {ValueError: 'Let us retry ValueError'}
 
         with self.assertRaises(IOError):
             smart_open.s3._retry_if_failed(partial, attempts=3, sleep_seconds=0, exceptions=exceptions)


### PR DESCRIPTION
#### Title

Please **pick a concise, informative and complete title** for your PR.
The title is important because it will appear in [our change log](https://github.com/RaRe-Technologies/smart_open/blob/master/CHANGELOG.md).

#### Motivation

Please explain the motivation behind this PR in the description.

If you're fixing a bug, link to the issue number like so:

- Fixes #628

If you're adding a new feature, then consider opening a ticket and discussing it with the maintainers before you actually do the hard work.

#### Tests

If you're fixing a bug, consider [test-driven development](https://en.wikipedia.org/wiki/Test-driven_development):

1. Create a unit test that demonstrates the bug. The test should **fail**.
2. Implement your bug fix.
3. The test you created should now **pass**.

If you're implementing a new feature, include unit tests for it.

Make sure all existing unit tests pass.
You can run them locally using:

    pytest smart_open

If there are any failures, please fix them before creating the PR (or mark it as WIP, see below).

#### Work in progress

If you're still working on your PR, include "WIP" in the title.
We'll skip reviewing it for the time being.
Once you're ready to review, remove the "WIP" from the title, and ping one of the maintainers (e.g. mpenkov).

#### Checklist

Before you create the PR, please make sure you have:

- [ ] Picked a concise, informative and complete title
- [ ] Clearly explained the motivation behind the PR
- [ ] Linked to any existing issues that your PR will be solving
- [ ] Included tests for any new functionality
- [ ] Checked that all unit tests pass

#### Workflow

Please avoid rebasing and force-pushing to the branch of the PR once a review is in progress.
Rebasing can make your commits look a bit cleaner, but it also makes life more difficult from the reviewer, because they are no longer able to distinguish between code that has already been reviewed, and unreviewed code.
