### PR TITLE
Propagate __exit__ call to underlying filestream

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ __version__ = _get_version()
 def read(fname):
     return io.open(os.path.join(os.path.dirname(__file__), fname), encoding='utf-8').read()
 
-
+base_deps = ['wrapt']
 aws_deps = ['boto3']
 gcs_deps = ['google-cloud-storage>=2.6.0']
 azure_deps = ['azure-storage-blob', 'azure-common', 'azure-core']
@@ -70,6 +70,7 @@ setup(
     license='MIT',
     platforms='any',
 
+    install_requires=base_deps,
     tests_require=tests_require,
     extras_require={
         'test': tests_require,

--- a/smart_open/compression.py
+++ b/smart_open/compression.py
@@ -79,8 +79,18 @@ def tweak_close(outer, inner):
     https://github.com/RaRe-Technologies/smart_open/issues/630 for an
     explanation why that is a problem for smart_open.
     """
-    from smart_open.utils import propagate_wrapped_method as _propagate_wrapped_method
-    _propagate_wrapped_method(outer, inner, "close")
+    outer_close = outer.close
+
+    def close_both(*args):
+        nonlocal inner
+        try:
+            outer_close()
+        finally:
+            if inner:
+                inner, fp = None, inner
+                fp.close()
+
+    outer.close = close_both
 
 
 def _handle_bz2(file_obj, mode):

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -911,12 +911,14 @@ multipart upload may fail")
         """Cancel the underlying multipart upload."""
         if self._upload_id is None:
             return
+        logger.debug('%s: terminating multipart upload', self)
         self._client.abort_multipart_upload(
             Bucket=self._bucket,
             Key=self._key,
             UploadId=self._upload_id,
         )
         self._upload_id = None
+        logger.debug('%s: terminated multipart upload', self)
 
     def to_boto3(self, resource):
         """Create an **independent** `boto3.s3.Object` instance that points to

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -909,7 +909,8 @@ multipart upload may fail")
 
     def terminate(self):
         """Cancel the underlying multipart upload."""
-        assert self._upload_id, "no multipart upload in progress"
+        if self._upload_id is None:
+            return
         self._client.abort_multipart_upload(
             Bucket=self._bucket,
             Key=self._key,

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -826,6 +826,7 @@ multipart upload may fail")
         if self._buf.tell():
             self._upload_next_part()
 
+        logger.debug('%s: completing multipart upload', self)
         if self._total_bytes and self._upload_id:
             partial = functools.partial(
                 self._client.complete_multipart_upload,
@@ -844,7 +845,6 @@ multipart upload may fail")
             #
             # We work around this by creating an empty file explicitly.
             #
-            assert self._upload_id, "no multipart upload in progress"
             self._client.abort_multipart_upload(
                 Bucket=self._bucket,
                 Key=self._key,

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -41,6 +41,7 @@ from smart_open import transport
 from smart_open.compression import register_compressor  # noqa: F401
 from smart_open.utils import check_kwargs as _check_kwargs  # noqa: F401
 from smart_open.utils import inspect_kwargs as _inspect_kwargs  # noqa: F401
+from smart_open.utils import propagate_wrapped_method as _propagate_wrapped_method
 
 logger = logging.getLogger(__name__)
 
@@ -223,6 +224,7 @@ def open(
 
     binary = _open_binary_stream(uri, binary_mode, transport_params)
     decompressed = so_compression.compression_wrapper(binary, binary_mode, compression)
+    _propagate_wrapped_method(decompressed, binary, "__exit__")
 
     if 'b' not in mode or explicit_encoding is not None:
         decoded = _encoding_wrapper(
@@ -232,6 +234,7 @@ def open(
             errors=errors,
             newline=newline,
         )
+        _propagate_wrapped_method(decoded, decompressed, "__exit__")
     else:
         decoded = decompressed
 

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -24,7 +24,6 @@ import os.path as P
 import pathlib
 import urllib.parse
 import warnings
-from contextlib import contextmanager
 
 #
 # This module defines a function called smart_open so we cannot use
@@ -32,6 +31,7 @@ from contextlib import contextmanager
 #
 import smart_open.local_file as so_file
 import smart_open.compression as so_compression
+import smart_open.utils as so_utils
 
 from smart_open import doctools
 from smart_open import transport
@@ -249,14 +249,7 @@ def open(
             except AttributeError:
                 pass
 
-    @contextmanager
-    def context_wrapper():
-        with binary:
-            with decompressed:
-                with decoded as dec:
-                    yield dec
-
-    return context_wrapper().__enter__()
+    return so_utils.FileLikeProxy(decoded, binary)
 
 
 def _get_binary_mode(mode_str):

--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -565,6 +565,30 @@ class MultipartWriterTest(unittest.TestCase):
 
             assert actual == contents
 
+    def test_write_gz_with_error(self):
+        """Does s3 multipart upload abort when for a failed compressed file upload?"""
+        with self.assertRaises(ValueError):
+            with smart_open.open(
+                    f's3://{BUCKET_NAME}/{WRITE_KEY_NAME}',
+                    mode="wb",
+                    compression='.gz',
+                    transport_params={
+                        "multipart_upload": True,
+                        "min_part_size": 10,
+                    }
+            ) as fout:
+                fout.write(b"test12345678test12345678")
+                fout.write(b"test\n")
+
+                raise ValueError("some error")
+
+        # no multipart upload was committed:
+        # smart_open.s3.MultipartWriter.__exit__ was called
+        with self.assertRaises(OSError) as cm:
+            smart_open.s3.open(BUCKET_NAME, WRITE_KEY_NAME, 'rb')
+
+        assert 'The specified key does not exist.' in cm.exception.args[0]
+
 
 @moto.mock_s3
 class SinglepartWriterTest(unittest.TestCase):

--- a/smart_open/utils.py
+++ b/smart_open/utils.py
@@ -11,6 +11,7 @@
 import inspect
 import logging
 import urllib.parse
+from types import MethodType
 
 logger = logging.getLogger(__name__)
 
@@ -189,3 +190,20 @@ def safe_urlsplit(url):
 
     path = sr.path.replace(placeholder, '?')
     return urllib.parse.SplitResult(sr.scheme, sr.netloc, path, '', '')
+
+
+def propagate_wrapped_method(outer, inner, method):
+    """Patch `outer` object to also execute `method` of the wrapped `inner` object."""
+    if outer is inner:
+        return
+    method_outer = getattr(outer, method)
+    method_inner = getattr(inner, method)
+
+    def method_new(*args, **kwargs):
+        try:
+            method_outer(*args, **kwargs)
+        finally:
+            method_inner(*args, **kwargs)
+
+    # does not work for magic methods ref https://stackoverflow.com/a/74143992/5511061
+    setattr(outer, method, MethodType(method_new, outer))

--- a/smart_open/utils.py
+++ b/smart_open/utils.py
@@ -11,7 +11,6 @@
 import inspect
 import logging
 import urllib.parse
-from types import MethodType
 
 logger = logging.getLogger(__name__)
 
@@ -190,20 +189,3 @@ def safe_urlsplit(url):
 
     path = sr.path.replace(placeholder, '?')
     return urllib.parse.SplitResult(sr.scheme, sr.netloc, path, '', '')
-
-
-def propagate_wrapped_method(outer, inner, method):
-    """Patch `outer` object to also execute `method` of the wrapped `inner` object."""
-    if outer is inner:
-        return
-    method_outer = getattr(outer, method)
-    method_inner = getattr(inner, method)
-
-    def method_new(*args, **kwargs):
-        try:
-            method_outer(*args, **kwargs)
-        finally:
-            method_inner(*args, **kwargs)
-
-    # does not work for magic methods ref https://stackoverflow.com/a/74143992/5511061
-    setattr(outer, method, MethodType(method_new, outer))


### PR DESCRIPTION
#### Title

Propagate `__exit__` call to underlying filestream. 

No more need for `tweak_close` function: the double wrapping will now cause three calls to `__exit__`, which in turn will call `close`, first on the outermost filestream, working inward.

If a third party compression handler calls `close` on the inner filestream, the inner `__exit__` call will do a second call to `close` on the inner filestream, which will be ignored.

#### Motivation

Currently, the compression mechanic has a side-effect that `__exit__` is no longer called on the original filestream. Consequently, eg boto3 abort multipart upload is not called, causing lingering blobs that will be billed. 

- Supercedes https://github.com/RaRe-Technologies/smart_open/pull/752
- Fixes #684

#### Tests

✅ 

#### Work in progress

#### Checklist

Before you create the PR, please make sure you have:

- [x] Picked a concise, informative and complete title
- [x] Clearly explained the motivation behind the PR
- [x] Linked to any existing issues that your PR will be solving
- [x] Included tests for any new functionality
- [x] Checked that all unit tests pass

#### Workflow

Please avoid rebasing and force-pushing to the branch of the PR once a review is in progress.
Rebasing can make your commits look a bit cleaner, but it also makes life more difficult from the reviewer, because they are no longer able to distinguish between code that has already been reviewed, and unreviewed code.
