### PR TITLE
Make calls to smart_open.open() for GCS 1000x faster by avoiding unnecessary GCS API call

### DIFF
--- a/integration-tests/test_gcs.py
+++ b/integration-tests/test_gcs.py
@@ -28,6 +28,9 @@ def write_read(key, content, write_mode, read_mode, **kwargs):
     with smart_open.open(key, read_mode, **kwargs) as fin:
         return fin.read()
 
+def open_only(key, read_mode, **kwargs) -> None:
+    with smart_open.open(key, read_mode, **kwargs):
+        pass
 
 def read_length_prefixed_messages(key, read_mode, **kwargs):
     result = io.BytesIO()
@@ -121,3 +124,10 @@ def test_gcs_performance_small_reads(benchmark):
 
     actual = benchmark(read_length_prefixed_messages, key, 'rb', buffering=ONE_MIB)
     assert actual == one_megabyte_of_msgs
+
+def test_gcs_performance_open(benchmark):
+    # we don't need to use a uri that actually exists in order to call GCS's open()
+    key = "gs://some-bucket/some_blob.txt"
+    transport_params = {'client': google.cloud.storage.Client()}
+    benchmark(open_only, key, 'rb', transport_params=transport_params)
+    assert True

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,8 @@ tests_require = all_deps + [
     'responses',
     'boto3',
     'pytest',
-    'pytest-rerunfailures'
+    'pytest-rerunfailures',
+    'pytest-benchmark',
 ]
 
 setup(

--- a/smart_open/gcs.py
+++ b/smart_open/gcs.py
@@ -128,10 +128,7 @@ def Reader(bucket,
         warn_deprecated('line_terminator')
 
     bkt = client.bucket(bucket)
-    blob = bkt.get_blob(key)
-
-    if blob is None:
-        raise google.cloud.exceptions.NotFound(f'blob {key} not found in {bucket}')
+    blob = bkt.blob(key)
 
     return blob.open('rb', **blob_open_kwargs)
 


### PR DESCRIPTION
#### Motivation

`Bucket.get_blob` requires a roundtrip to GCS, but `Bucket.blob` doesn't, so let's use that instead. In my benchmarking, this change reduces the time taken to call `smart_open.open()` from milliseconds to microseconds. This is especially nice when you're repeatedly calling `smart_open.open` for a large list of files.

#### Tests

To run the new benchmark test:
```sh
pytest integration-tests/test_gcs.py::test_gcs_performance_open
```

`pytest-benchmark` comparison for old code vs. new code:
![image](https://github.com/piskvorky/smart_open/assets/3038603/5be4a830-63eb-4ac0-b001-1fb30c5dcb4f)