### PR TITLE
Fix `KeyError: 'ContentRange'` when received full content from S3

### DIFF
--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -486,9 +486,17 @@ class _SeekableRawReader(object):
                 self,
                 response['ResponseMetadata']['RetryAttempts'],
             )
-            _, start, stop, length = smart_open.utils.parse_content_range(response['ContentRange'])
+            # range request may not always return partial content, see
+            # https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests#partial_request_responses
+            status_code = response['ResponseMetadata']['HTTPStatusCode']
+            if status_code == 206:
+                # partial content
+                _, start, stop, length = smart_open.utils.parse_content_range(response['ContentRange'])
+                self._position = start
+            elif status_code == 200:
+                # full content
+                length = response["ContentLength"]
             self._content_length = length
-            self._position = start
             self._body = response['Body']
 
     def read(self, size=-1):

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -492,10 +492,10 @@ class _SeekableRawReader(object):
             # https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests#partial_request_responses
             #
             status_code = response['ResponseMetadata']['HTTPStatusCode']
-            if status_code == http.HttpStatus.PARTIAL_CONTENT:
+            if status_code == http.HTTPStatus.PARTIAL_CONTENT:
                 _, start, stop, length = smart_open.utils.parse_content_range(response['ContentRange'])
                 self._position = start
-            elif status_code == http.HttpStatus.OK:
+            elif status_code == http.HTTPStatus.OK:
                 length = response["ContentLength"]
             self._content_length = length
             self._body = response['Body']

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -7,6 +7,7 @@
 #
 """Implements file-like objects for reading and writing from/to AWS S3."""
 
+import http
 import io
 import functools
 import logging
@@ -486,15 +487,15 @@ class _SeekableRawReader(object):
                 self,
                 response['ResponseMetadata']['RetryAttempts'],
             )
-            # range request may not always return partial content, see
+            #
+            # range request may not always return partial content, see:
             # https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests#partial_request_responses
+            #
             status_code = response['ResponseMetadata']['HTTPStatusCode']
-            if status_code == 206:
-                # partial content
+            if status_code == http.HttpStatus.PARTIAL_CONTENT:
                 _, start, stop, length = smart_open.utils.parse_content_range(response['ContentRange'])
                 self._position = start
-            elif status_code == 200:
-                # full content
+            elif status_code == http.HttpStatus.OK:
                 length = response["ContentLength"]
             self._content_length = length
             self._body = response['Body']

--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -150,7 +150,7 @@ class CrapClient:
             'ContentLength': self._datasize,
             'ContentRange': 'bytes 0-%d/%d' % (self._datasize, self._datasize),
             'Body': self._body,
-            'ResponseMetadata': {'RetryAttempts': 1},
+            'ResponseMetadata': {'RetryAttempts': 1, "HTTPStatusCode": 206},
         }
 
 

--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -150,7 +150,7 @@ class CrapClient:
             'ContentLength': self._datasize,
             'ContentRange': 'bytes 0-%d/%d' % (self._datasize, self._datasize),
             'Body': self._body,
-            'ResponseMetadata': {'RetryAttempts': 1, "HTTPStatusCode": 206},
+            'ResponseMetadata': {'RetryAttempts': 1, 'HTTPStatusCode': 206},
         }
 
 


### PR DESCRIPTION
#### Motivation

https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests#partial_request_responses

> If range requests are not supported, an [200](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200) OK status is sent back and the entire response body is transmitted.

In case there is a proxy between s3 and end user, range requests may not be supported.

Fixes #686

#### Checklist

Before you create the PR, please make sure you have:

- [x] Picked a concise, informative and complete title
- [x] Clearly explained the motivation behind the PR
- [x] Linked to any existing issues that your PR will be solving
- [ ] Included tests for any new functionality
- [x] Checked that all unit tests pass
