### PR TITLE
Add support for SSH connection via aliases from `~/.ssh/config`

### DIFF
--- a/smart_open/ssh.py
+++ b/smart_open/ssh.py
@@ -129,7 +129,6 @@ def _maybe_fetch_config(host, username=None, password=None, port=None, transport
     # - compression selection
     # - GSS configuration
     for config_filename in _SSH_CONFIG_FILES:
-        print(config_filename)
         if os.path.exists(config_filename):
             try:
                 cfg = paramiko.SSHConfig.from_path(config_filename)

--- a/smart_open/ssh.py
+++ b/smart_open/ssh.py
@@ -76,6 +76,7 @@ def _str2bool(string):
         return True
     raise ValueError(f"Expected 'yes' / 'no', got {string}.")
 
+
 #
 # The parameter names used by Paramiko (and smart_open) slightly differ to
 # those used in ~/.ssh/config, so we use a mapping to bridge the gap.

--- a/smart_open/ssh.py
+++ b/smart_open/ssh.py
@@ -108,18 +108,18 @@ def _maybe_fetch_config(host, username=None, password=None, port=None, transport
     # If all fields are set, return as-is.
     if not any(arg is None for arg in (host, username, password, port, transport_params)):
         return host, username, password, port, transport_params
-    
+
     if not host:
         raise ValueError('you must specify the host to connect to')
     if not transport_params:
         transport_params = {}
     if "connect_kwargs" not in transport_params:
         transport_params["connect_kwargs"] = {}
-    
+
     # Attempt to load an OpenSSH config.
     # NOTE: connections configured in this way are not guaranteed to perform exactly as
     # they do in typical usage due to mismatches between the set of OpenSSH configuration
-    # options and those that Paramiko supports. We provide a best attempt, 
+    # options and those that Paramiko supports. We provide a best attempt,
     # and support:
     # - hostname -> address resolution
     # - username inference
@@ -144,9 +144,9 @@ def _maybe_fetch_config(host, username=None, password=None, port=None, transport
 
                 # Special case, as we can have multiple identity files, so we check that the
                 # identityfile list has len > 0. This should be redundant, but keeping it for safety.
-                if (transport_params["connect_kwargs"].get("key_filename", None) is None and
-                    "identityfile" in cfg and len(cfg.get("identityfile", []))
-                ):
+                if (transport_params["connect_kwargs"].get("key_filename", None) is None
+                    and "identityfile" in cfg and len(cfg.get("identityfile", []))
+                    ):
                     transport_params["connect_kwargs"]["key_filename"] = cfg["identityfile"]
 
                 # Map parameters from config to their required values for Paramiko's `connect` fn.
@@ -206,8 +206,9 @@ def open(path, mode='r', host=None, user=None, password=None, port=None, transpo
     If ``username`` or ``password`` are specified in *both* the uri and
     ``transport_params``, ``transport_params`` will take precedence
     """
-    
-    host, user, password, port, transport_params = _maybe_fetch_config(host, user, password, port, transport_params)
+    host, user, password, port, transport_params = _maybe_fetch_config(
+        host, user, password, port, transport_params
+    )
 
     key = (host, user)
 

--- a/smart_open/tests/test_data/ssh.cfg
+++ b/smart_open/tests/test_data/ssh.cfg
@@ -1,0 +1,11 @@
+Host another-host
+  HostName another-host-domain.com
+  User another-user
+  Port 2345
+  IdentityFile /path/to/key/file
+  ConnectTimeout 20
+  Compression yes
+  GSSAPIAuthentication no
+  GSSAPIKeyExchange no
+  GSSAPIDelegateCredentials no
+  GSSAPITrustDns no

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -309,7 +309,7 @@ class ParseUriTest(unittest.TestCase):
         self.assertEqual(uri.uri_path, '/path/to/file')
         self.assertEqual(uri.user, 'user')
         self.assertEqual(uri.host, 'host')
-        self.assertEqual(uri.port, 22)
+        self.assertEqual(uri.port, None)
         self.assertEqual(uri.password, None)
 
     def test_scp_with_pass(self):
@@ -319,7 +319,7 @@ class ParseUriTest(unittest.TestCase):
         self.assertEqual(uri.uri_path, '/path/to/file')
         self.assertEqual(uri.user, 'user')
         self.assertEqual(uri.host, 'host')
-        self.assertEqual(uri.port, 22)
+        self.assertEqual(uri.port, None)
         self.assertEqual(uri.password, 'pass')
 
     def test_sftp(self):
@@ -329,7 +329,7 @@ class ParseUriTest(unittest.TestCase):
         self.assertEqual(uri.uri_path, '/path/to/file')
         self.assertEqual(uri.user, None)
         self.assertEqual(uri.host, 'host')
-        self.assertEqual(uri.port, 22)
+        self.assertEqual(uri.port, None)
         self.assertEqual(uri.password, None)
 
     def test_sftp_with_user_and_pass(self):

--- a/smart_open/tests/test_ssh.py
+++ b/smart_open/tests/test_ssh.py
@@ -104,6 +104,23 @@ Host another-host
             gss_auth=False, gss_kex=False, gss_deleg_creds=False, gss_trust_dns=False
         )
 
+    @mock_ssh
+    def test_open_with_openssh_config_override_port(self, mock_connect, get_transp_mock):
+        smart_open.open("ssh://another-host:22/")
+        mock_connect.assert_called_with(
+            "another-host-domain.com", 22, username="another-user",
+            key_filename=["/path/to/key/file"], timeout=20., compress=True,
+            gss_auth=False, gss_kex=False, gss_deleg_creds=False, gss_trust_dns=False
+        )
+
+    @mock_ssh
+    def test_open_with_openssh_config_override_user(self, mock_connect, get_transp_mock):
+        smart_open.open("ssh://new-user@another-host/")
+        mock_connect.assert_called_with(
+            "another-host-domain.com", 2345, username="new-user",
+            key_filename=["/path/to/key/file"], timeout=20., compress=True,
+            gss_auth=False, gss_kex=False, gss_deleg_creds=False, gss_trust_dns=False
+        )
 
 if __name__ == "__main__":
     logging.basicConfig(format="%(asctime)s : %(levelname)s : %(message)s", level=logging.DEBUG)

--- a/smart_open/tests/test_ssh.py
+++ b/smart_open/tests/test_ssh.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import copy
 import logging
 import os
 import tempfile
@@ -121,6 +120,7 @@ Host another-host
             key_filename=["/path/to/key/file"], timeout=20., compress=True,
             gss_auth=False, gss_kex=False, gss_deleg_creds=False, gss_trust_dns=False
         )
+
 
 if __name__ == "__main__":
     logging.basicConfig(format="%(asctime)s : %(levelname)s : %(message)s", level=logging.DEBUG)

--- a/smart_open/tests/test_ssh.py
+++ b/smart_open/tests/test_ssh.py
@@ -2,10 +2,8 @@
 
 import logging
 import os
-import tempfile
 import unittest
 from unittest import mock
-import uuid
 
 from paramiko import SSHException
 

--- a/smart_open/tests/test_ssh.py
+++ b/smart_open/tests/test_ssh.py
@@ -11,6 +11,9 @@ from paramiko import SSHException
 
 import smart_open.ssh
 
+_TEST_DATA_PATH = os.path.join(os.path.dirname(__file__), "test_data")
+_CONFIG_PATH = os.path.join(_TEST_DATA_PATH, "ssh.cfg")
+
 
 def mock_ssh(func):
     def wrapper(*args, **kwargs):
@@ -23,28 +26,12 @@ def mock_ssh(func):
 
 
 class SSHOpen(unittest.TestCase):
-    MOCK_SSH_CONFIG = r"""
-Host another-host
-  HostName another-host-domain.com
-  User another-user
-  Port 2345
-  IdentityFile /path/to/key/file
-  ConnectTimeout 20
-  Compression yes
-  GSSAPIAuthentication no
-  GSSAPIKeyExchange no
-  GSSAPIDelegateCredentials no
-  GSSAPITrustDns no
-"""
-
     def setUp(self):
-        self.mock_ssh_config_file = os.path.join(tempfile.gettempdir(), "config-" + str(uuid.uuid1()))
-        smart_open.ssh._SSH_CONFIG_FILES[0] = self.mock_ssh_config_file
-        with open(self.mock_ssh_config_file, 'w') as file:
-            file.write(self.MOCK_SSH_CONFIG)
+        self._cfg_files = smart_open.ssh._SSH_CONFIG_FILES
+        smart_open.ssh._SSH_CONFIG_FILES = [_CONFIG_PATH]
 
     def tearDown(self):
-        os.remove(self.mock_ssh_config_file)
+        smart_open.ssh._SSH_CONFIG_FILES = self._cfg_files
 
     @mock_ssh
     def test_open(self, mock_connect, get_transp_mock):
@@ -98,27 +85,48 @@ Host another-host
     def test_open_with_openssh_config(self, mock_connect, get_transp_mock):
         smart_open.open("ssh://another-host/")
         mock_connect.assert_called_with(
-            "another-host-domain.com", 2345, username="another-user",
-            key_filename=["/path/to/key/file"], timeout=20., compress=True,
-            gss_auth=False, gss_kex=False, gss_deleg_creds=False, gss_trust_dns=False
+            "another-host-domain.com",
+            2345,
+            username="another-user",
+            key_filename=["/path/to/key/file"],
+            timeout=20.,
+            compress=True,
+            gss_auth=False,
+            gss_kex=False,
+            gss_deleg_creds=False,
+            gss_trust_dns=False,
         )
 
     @mock_ssh
     def test_open_with_openssh_config_override_port(self, mock_connect, get_transp_mock):
         smart_open.open("ssh://another-host:22/")
         mock_connect.assert_called_with(
-            "another-host-domain.com", 22, username="another-user",
-            key_filename=["/path/to/key/file"], timeout=20., compress=True,
-            gss_auth=False, gss_kex=False, gss_deleg_creds=False, gss_trust_dns=False
+            "another-host-domain.com",
+            22,
+            username="another-user",
+            key_filename=["/path/to/key/file"],
+            timeout=20.,
+            compress=True,
+            gss_auth=False,
+            gss_kex=False,
+            gss_deleg_creds=False,
+            gss_trust_dns=False,
         )
 
     @mock_ssh
     def test_open_with_openssh_config_override_user(self, mock_connect, get_transp_mock):
         smart_open.open("ssh://new-user@another-host/")
         mock_connect.assert_called_with(
-            "another-host-domain.com", 2345, username="new-user",
-            key_filename=["/path/to/key/file"], timeout=20., compress=True,
-            gss_auth=False, gss_kex=False, gss_deleg_creds=False, gss_trust_dns=False
+            "another-host-domain.com",
+            2345,
+            username="new-user",
+            key_filename=["/path/to/key/file"],
+            timeout=20.,
+            compress=True,
+            gss_auth=False,
+            gss_kex=False,
+            gss_deleg_creds=False,
+            gss_trust_dns=False,
         )
 
 


### PR DESCRIPTION
#### Add support for SSH connection via aliases from `~/.ssh/config`
#### Motivation

For commonly-used connections, machines with pre-existing SSH configurations, and general convenience, we find it useful to be able to infer (or interpolate, as you please) a full connection configuration from the host alias in the standard SSH config file.

We suggest that configurations as specified as such should only be used as default values, and if alternatives username and port are provided as part of the file URI, these should override pre-existing values. For example, `ssh://new-user@host-alias:<new-port>/...` should override the pre-defined port and username in the SSH configuration file. 

#### Implementation Details

As currently implemented, the connection configuration interpolation supports the following configuration options, which are passed to `paramiko.client.SSHClient.connect`:

- hostname
- port
- username
- key_filename
- timeout
- compress
- gss_auth
- gss_kex
- gss_deleg_creds
- gss_trust_dns

As an example, the following configuration would be fully and properly utilised when called with `smart_open.open("ssh://another-host/...")`

```
Host another-host
  HostName another-host-domain.com
  User another-user
  Port 2345
  IdentityFile /path/to/key/file
  ConnectTimeout 20
  Compression yes
  GSSAPIAuthentication no
  GSSAPIKeyExchange no
  GSSAPIDelegateCredentials no
  GSSAPITrustDns no
```

#### Tests

Additional unit tests have been added in `smart_open/tests/test_ssh.py`, following the existing test pattern.

#### Checklist

Before you create the PR, please make sure you have:

- [x] Picked a concise, informative and complete title
- [x] Clearly explained the motivation behind the PR
- [x] Included tests for any new functionality
- [x] Checked that all unit tests pass
