### PR TITLE
Fix __str__ method in SinglepartWriter

### DIFF
--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -1104,7 +1104,7 @@ class SinglepartWriter(io.BufferedIOBase):
             self.close()
 
     def __str__(self):
-        return "smart_open.s3.SinglepartWriter(%r, %r)" % (self._object.bucket_name, self._object.key)
+        return "smart_open.s3.SinglepartWriter(%r, %r)" % (self._bucket, self._key)
 
     def __repr__(self):
         return "smart_open.s3.SinglepartWriter(bucket=%r, key=%r)" % (self._bucket, self._key)

--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -675,7 +675,7 @@ class SinglepartWriterTest(unittest.TestCase):
     def test_str(self):
         """Check the stringifying works!"""
         fout = smart_open.s3.open(BUCKET_NAME, 'key', 'wb', multipart_upload=False)
-        fout.write(text)
+        fout.write(b"text")
         fout.flush()
         fout.close()
         assert str(fout) != ''

--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -672,6 +672,14 @@ class SinglepartWriterTest(unittest.TestCase):
 
             assert actual == contents
 
+    def test_str(self):
+        """Check the stringifying works!"""
+        fout = smart_open.s3.open(BUCKET_NAME, 'key', 'wb', multipart_upload=False)
+        fout.write(text)
+        fout.flush()
+        fout.close()
+        assert str(fout) != ''
+
 
 ARBITRARY_CLIENT_ERROR = botocore.client.ClientError(error_response={}, operation_name='bar')
 

--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -673,12 +673,8 @@ class SinglepartWriterTest(unittest.TestCase):
             assert actual == contents
 
     def test_str(self):
-        """Check the stringifying works!"""
-        fout = smart_open.s3.open(BUCKET_NAME, 'key', 'wb', multipart_upload=False)
-        fout.write(b"text")
-        fout.flush()
-        fout.close()
-        assert str(fout) != ''
+        with smart_open.s3.open(BUCKET_NAME, 'key', 'wb', multipart_upload=False) as fout:
+            assert str(fout) == "smart_open.s3.SinglepartWriter('test-smartopen', 'key')"
 
 
 ARBITRARY_CLIENT_ERROR = botocore.client.ClientError(error_response={}, operation_name='bar')


### PR DESCRIPTION
#### Title

Fix __str__ method in SinglepartWriter

#### Motivation

- Fixes #671 

The bug here means that whenever you open an s3 connection and switch multipart writing off because the file is small, although the write completes successfully, you get an exception thrown when the code logs a debug message saying it has finished. This makes it look like your transfer has failed.

#### Tests

Added test

#### Checklist

Before you create the PR, please make sure you have:

- [x] Picked a concise, informative and complete title
- [x] Clearly explained the motivation behind the PR
- [x] Linked to any existing issues that your PR will be solving
- [x] Included tests for any new functionality
- [x] Checked that all unit tests pass

#### Workflow

Please avoid rebasing and force-pushing to the branch of the PR once a review is in progress.
Rebasing can make your commits look a bit cleaner, but it also makes life more difficult from the reviewer, because they are no longer able to distinguish between code that has already been reviewed, and unreviewed code.
