### PR TITLE
Add logic for handling large files in MultipartWriter uploads to s3

### DIFF
--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -40,8 +40,6 @@ DEFAULT_MIN_PART_SIZE = 50 * 1024**2
 MIN_MIN_PART_SIZE = 5 * 1024 ** 2
 """The absolute minimum permitted by Amazon."""
 
-DEFAULT_MAX_PART_SIZE = 5 * 1024**3
-"""Default maximum part size for S3 multipart uploads"""
 MAX_MAX_PART_SIZE = 5 * 1024 ** 3
 """The absolute maximum permitted by Amazon."""
 
@@ -258,7 +256,7 @@ def open(
     client=None,
     client_kwargs=None,
     writebuffer=None,
-    max_part_size=DEFAULT_MAX_PART_SIZE
+    max_part_size=MAX_MAX_PART_SIZE,
 ):
     """Open an S3 object for reading or writing.
 
@@ -793,7 +791,7 @@ class MultipartWriter(io.BufferedIOBase):
         client=None,
         client_kwargs=None,
         writebuffer: io.BytesIO | None = None,
-        max_part_size=DEFAULT_MAX_PART_SIZE
+        max_part_size=MAX_MAX_PART_SIZE,
     ):
         if min_part_size < MIN_MIN_PART_SIZE:
             logger.warning(

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -792,19 +792,26 @@ class MultipartWriter(io.BufferedIOBase):
         min_part_size=DEFAULT_MIN_PART_SIZE,
         client=None,
         client_kwargs=None,
-        writebuffer: io.BytesIO|None=None,
+        writebuffer: io.BytesIO | None = None,
         max_part_size=DEFAULT_MAX_PART_SIZE
     ):
         if min_part_size < MIN_MIN_PART_SIZE:
-            logger.warning(f"min_part_size set to {min_part_size}; "
-                    "S3 requires minimum part size >= 5MiB; "
-"multipart upload may fail")
+            logger.warning(
+                f"min_part_size set to {min_part_size}; "
+                "S3 requires minimum part size >= 5MiB; "
+                "multipart upload may fail"
+            )
         if max_part_size > MAX_MAX_PART_SIZE:
-            logger.warning(f"max_part_size set to {max_part_size}; "
-            "S3 requires maximum part size <= 5GiB; "
-"multipart upload may fail")
+            logger.warning(
+                f"max_part_size set to {max_part_size}; "
+                "S3 requires maximum part size <= 5GiB; "
+                "multipart upload may fail"
+            )
         if max_part_size < min_part_size:
-            logger.warning(f"max_part_size {max_part_size} smaller than min_part_size {min_part_size}. Setting min_part_size to max_part_size")
+            logger.warning(
+                f"max_part_size {max_part_size} smaller than min_part_size {min_part_size}. "
+                "Setting min_part_size to max_part_size"
+            )
             min_part_size = max_part_size
             # Raise error instead?
         self._min_part_size = min_part_size
@@ -948,7 +955,6 @@ class MultipartWriter(io.BufferedIOBase):
             self._upload_next_part()
             i += end-start
         return len(mv)
-
 
     def terminate(self):
         """Cancel the underlying multipart upload."""

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -51,7 +51,7 @@ MIN_PART_SIZE = 5 * 1024 ** 2
 """The absolute minimum permitted by Amazon."""
 
 DEFAULT_PART_SIZE = 50 * 1024**2
-"""Default minimum part size for S3 multipart uploads"""
+"""The default part size for S3 multipart uploads, chosen carefully by smart_open"""
 
 MAX_PART_SIZE = 5 * 1024 ** 3
 """The absolute maximum permitted by Amazon."""

--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -456,34 +456,58 @@ class MultipartWriterTest(unittest.TestCase):
 
     def test_write_03(self):
         """Does s3 multipart chunking work correctly?"""
-        min_ps = smart_open.s3.MIN_PART_SIZE
-        max_ps = smart_open.s3.MAX_PART_SIZE
 
-        try:
-            smart_open.s3.MIN_PART_SIZE = 1
-            smart_open.s3.MAX_PART_SIZE = 100
+        #
+        # generate enough test data for a single multipart upload part.
+        # We need this because moto behaves like S3; it refuses to upload
+        # parts smaller than 5MB.
+        #
+        data_dir = os.path.join(os.path.dirname(__file__), "test_data")
+        with open(os.path.join(data_dir, "crime-and-punishment.txt"), "rb") as fin:
+            crime = fin.read()
+        data = b''
+        ps = 5 * 1024 * 1024
+        while len(data) < ps:
+            data += crime
 
-            smart_open_write = smart_open.s3.MultipartWriter(
-                BUCKET_NAME, WRITE_KEY_NAME, min_part_size=10
-            )
-            with smart_open_write as fout:
-                fout.write(b"test")
-                self.assertEqual(fout._buf.tell(), 4)
+        title = "Преступление и наказание\n\n".encode()
+        to_be_continued = "\n\n... продолжение следует ...\n\n".encode()
 
-                fout.write(b"test\n")
-                self.assertEqual(fout._buf.tell(), 9)
-                self.assertEqual(fout._total_parts, 0)
+        with smart_open.s3.MultipartWriter(BUCKET_NAME, WRITE_KEY_NAME, part_size=ps) as fout:
+            #
+            # Write some data without triggering an upload
+            #
+            fout.write(title)
+            assert fout._total_parts == 0
+            assert fout._buf.tell() == 48
 
-                fout.write(b"test")
-                self.assertEqual(fout._buf.tell(), 0)
-                self.assertEqual(fout._total_parts, 1)
-        finally:
-            smart_open.s3.MIN_PART_SIZE = min_ps
-            smart_open.s3.MAX_PART_SIZE = max_ps
+            #
+            # Trigger a part upload
+            #
+            fout.write(data)
+            assert fout._total_parts == 1
+            assert fout._buf.tell() == 661
 
+            #
+            # Write _without_ triggering a part upload
+            #
+            fout.write(to_be_continued)
+            assert fout._total_parts == 1
+            assert fout._buf.tell() == 710
+
+        #
+        # We closed the writer, so the final part must have been uploaded
+        #
+        assert fout._buf.tell() == 0
+        assert fout._total_parts == 2
+
+        #
         # read back the same key and check its content
-        output = list(smart_open.s3.open(BUCKET_NAME, WRITE_KEY_NAME, 'rb'))
-        self.assertEqual(output, [b"testtest\n", b"test"])
+        #
+        with smart_open.s3.open(BUCKET_NAME, WRITE_KEY_NAME, 'rb') as fin:
+            got = fin.read()
+        want = title + data + to_be_continued
+        assert want == got
 
     def test_write_04(self):
         """Does writing no data cause key with an empty value to be created?"""
@@ -573,57 +597,6 @@ class MultipartWriterTest(unittest.TestCase):
                 actual = fin.read()
 
             assert actual == contents
-
-    def test_max_part_size_1(self) -> None:
-        """write successive chunks of size 5MiB-1 with a min_part_size of 5MiB and max_part_size=7MiB
-
-        There are no minimum size limits of the last part of a multipart upload, which
-        is why test_write03 can get away with small test data. But since we need to get
-        multiple parts we cannot avoid that.
-        """
-        contents = bytes(5 * 2**20 - 1)
-
-        with smart_open.s3.open(
-            BUCKET_NAME,
-            WRITE_KEY_NAME,
-            "wb",
-            min_part_size=5 * 2**20,
-            max_part_size=7 * 2**20,
-        ) as fout:
-            fout.write(contents)
-            assert fout._total_parts == 0
-            assert fout._buf.tell() == 5 * 2**20 - 1
-
-            fout.write(contents)
-            assert fout._total_parts == 1
-            assert fout._buf.tell() == 3 * 2**20 - 2
-
-            fout.write(contents)
-            assert fout._total_parts == 2
-            assert fout._buf.tell() == 1 * 2**20 - 3
-        contents = b""
-
-        output = list(smart_open.s3.open(BUCKET_NAME, WRITE_KEY_NAME, "rb"))
-        assert len(output[0]) == 3 * (5 * 2**20 - 1)
-
-    def test_max_part_size_2(self) -> None:
-        """Do a single big write of 15MiB with a max_part_size of 5MiB"""
-        contents = bytes(15 * 2**20)
-
-        with smart_open.s3.open(
-            BUCKET_NAME,
-            WRITE_KEY_NAME,
-            "wb",
-            min_part_size=5 * 2**20,
-            max_part_size=5 * 2**20,
-        ) as fout:
-            fout.write(contents)
-            assert fout._total_parts == 3
-            assert fout._buf.tell() == 0
-        contents = b""
-
-        output = list(smart_open.s3.open(BUCKET_NAME, WRITE_KEY_NAME, "rb"))
-        assert len(output[0]) == 15 * 2**20
 
 
 @moto.mock_s3

--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -193,8 +193,8 @@ class IncrementalBackoffTest(unittest.TestCase):
 class ReaderTest(BaseTest):
     def setUp(self):
         # lower the multipart upload size, to speed up these tests
-        self.old_min_part_size = smart_open.s3.DEFAULT_MIN_PART_SIZE
-        smart_open.s3.DEFAULT_MIN_PART_SIZE = 5 * 1024**2
+        self.old_min_part_size = smart_open.s3.DEFAULT_PART_SIZE
+        smart_open.s3.DEFAULT_PART_SIZE = 5 * 1024**2
 
         ignore_resource_warnings()
 
@@ -207,7 +207,7 @@ class ReaderTest(BaseTest):
         s3.Object(BUCKET_NAME, KEY_NAME).put(Body=self.body)
 
     def tearDown(self):
-        smart_open.s3.DEFAULT_MIN_PART_SIZE = self.old_min_part_size
+        smart_open.s3.DEFAULT_PART_SIZE = self.old_min_part_size
 
     def test_iter(self):
         """Are S3 files iterated over correctly?"""

--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -461,6 +461,10 @@ class MultipartWriterTest(unittest.TestCase):
             fout.write(u"testžížáč".encode("utf-8"))
             self.assertEqual(fout.tell(), 14)
 
+    #
+    # Nb. Under Windows, the byte offsets are different for some reason
+    #
+    @pytest.mark.skipif(condition=sys.platform == 'win32', reason="does not run on windows")
     def test_write_03(self):
         """Does s3 multipart chunking work correctly?"""
 

--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -568,38 +568,53 @@ class MultipartWriterTest(unittest.TestCase):
     def test_max_part_size_1(self) -> None:
         """write successive chunks of size 5MiB-1 with a min_part_size of 5MiB and max_part_size=7MiB
 
-        There are no minimum size limits of the last part of a multipart upload, which is why test_write03 can get away with small test data. But since we need to get multiple parts we cannot avoid that."""
-        contents = bytes(5 * 2**20-1)
+        There are no minimum size limits of the last part of a multipart upload, which
+        is why test_write03 can get away with small test data. But since we need to get
+        multiple parts we cannot avoid that.
+        """
+        contents = bytes(5 * 2**20 - 1)
 
-        with smart_open.s3.open(BUCKET_NAME, WRITE_KEY_NAME, 'wb', min_part_size=5*2**20, max_part_size=7*2**20) as fout:
+        with smart_open.s3.open(
+            BUCKET_NAME,
+            WRITE_KEY_NAME,
+            "wb",
+            min_part_size=5 * 2**20,
+            max_part_size=7 * 2**20,
+        ) as fout:
             fout.write(contents)
             assert fout._total_parts == 0
-            assert fout._buf.tell() == 5*2**20-1
+            assert fout._buf.tell() == 5 * 2**20 - 1
 
             fout.write(contents)
             assert fout._total_parts == 1
-            assert fout._buf.tell() == 3*2**20-2
+            assert fout._buf.tell() == 3 * 2**20 - 2
 
             fout.write(contents)
             assert fout._total_parts == 2
-            assert fout._buf.tell() == 1*2**20-3
-        contents = b''
+            assert fout._buf.tell() == 1 * 2**20 - 3
+        contents = b""
 
         output = list(smart_open.s3.open(BUCKET_NAME, WRITE_KEY_NAME, "rb"))
-        assert len(output[0]) == 3*(5*2**20-1)
+        assert len(output[0]) == 3 * (5 * 2**20 - 1)
 
     def test_max_part_size_2(self) -> None:
         """Do a single big write of 15MiB with a max_part_size of 5MiB"""
         contents = bytes(15 * 2**20)
 
-        with smart_open.s3.open(BUCKET_NAME, WRITE_KEY_NAME, 'wb', min_part_size=5*2**20, max_part_size=5*2**20) as fout:
+        with smart_open.s3.open(
+            BUCKET_NAME,
+            WRITE_KEY_NAME,
+            "wb",
+            min_part_size=5 * 2**20,
+            max_part_size=5 * 2**20,
+        ) as fout:
             fout.write(contents)
             assert fout._total_parts == 3
             assert fout._buf.tell() == 0
-        contents = b''
+        contents = b""
 
         output = list(smart_open.s3.open(BUCKET_NAME, WRITE_KEY_NAME, "rb"))
-        assert len(output[0]) == 15*2**20
+        assert len(output[0]) == 15 * 2**20
 
 
 @moto.mock_s3

--- a/smart_open/version.py
+++ b/smart_open/version.py
@@ -1,4 +1,4 @@
-__version__ = '6.4.0'
+__version__ = '6.4.0.dev0'
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
fixes #380

I'll likely go through the PR later and add a couple more comments, but otherwise it's done.

It'd be great if botocore allowed `memoryview`s to be directly passed to it, which would mean we wouldn't need to write a copy of the data in the buffer. But we probably don't want to wait for if/when https://github.com/boto/botocore/pull/3107 is merged+released


I added a couple types as I was working to understand the current code, and given #518 I thought I might as well keep them. But can remove them if you don't want a couple random types hanging around.