### PR TITLE
Add zstandard compression feature

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,8 +41,9 @@ gcs_deps = ['google-cloud-storage>=2.6.0']
 azure_deps = ['azure-storage-blob', 'azure-common', 'azure-core']
 http_deps = ['requests']
 ssh_deps = ['paramiko']
+zst_deps = ['zstandard']
 
-all_deps = aws_deps + gcs_deps + azure_deps + http_deps + ssh_deps
+all_deps = aws_deps + gcs_deps + azure_deps + http_deps + ssh_deps + zst_deps
 tests_require = all_deps + [
     'moto[server]<5.0',
     'responses',
@@ -80,6 +81,7 @@ setup(
         'http': http_deps,
         'webhdfs': http_deps,
         'ssh': ssh_deps,
+        'zst': zst_deps,
     },
     python_requires=">=3.6,<4.0",
 

--- a/smart_open/compression.py
+++ b/smart_open/compression.py
@@ -103,6 +103,11 @@ def _handle_gzip(file_obj, mode):
     tweak_close(result, file_obj)
     return result
 
+def _handle_zstd(file_obj, mode):
+    import zstandard as zstd
+    result = zstd.ZstdDecompressor().stream_reader(file_obj, closefd=True)
+    return result
+
 
 def compression_wrapper(file_obj, mode, compression=INFER_FROM_EXTENSION, filename=None):
     """
@@ -145,3 +150,4 @@ def compression_wrapper(file_obj, mode, compression=INFER_FROM_EXTENSION, filena
 #
 register_compressor('.bz2', _handle_bz2)
 register_compressor('.gz', _handle_gzip)
+register_compressor('.zst', _handle_zstd)

--- a/smart_open/tests/test_compression.py
+++ b/smart_open/tests/test_compression.py
@@ -11,6 +11,9 @@ import pytest
 
 import smart_open.compression
 
+import zstandard as zstd
+
+
 
 plain = 'доброе утро планета!'.encode()
 
@@ -32,6 +35,10 @@ def label(thing, name):
         (io.BytesIO(gzip.compress(plain)), 'infer_from_extension', 'file.GZ'),
         (label(io.BytesIO(gzip.compress(plain)), 'file.gz'), 'infer_from_extension', ''),
         (io.BytesIO(gzip.compress(plain)), '.gz', 'file.gz'),
+        (io.BytesIO(zstd.ZstdCompressor().compress(plain)), 'infer_from_extension', 'file.zst'),
+        (io.BytesIO(zstd.ZstdCompressor().compress(plain)), 'infer_from_extension', 'file.ZST'),
+        (label(io.BytesIO(zstd.ZstdCompressor().compress(plain)), 'file.zst'), 'infer_from_extension', ''),
+        (io.BytesIO(zstd.ZstdCompressor().compress(plain)), '.zst', 'file.zst'),
     ]
 )
 def test_compression_wrapper_read(fileobj, compression, filename):

--- a/smart_open/tests/test_compression.py
+++ b/smart_open/tests/test_compression.py
@@ -5,15 +5,13 @@
 # This code is distributed under the terms and conditions
 # from the MIT License (MIT).
 #
-import io
 import gzip
+import io
+
 import pytest
-
-import smart_open.compression
-
 import zstandard as zstd
 
-
+import smart_open.compression
 
 plain = 'доброе утро планета!'.encode()
 


### PR DESCRIPTION
Adds zstandard compression support, as requested in #799. 

I made it an optional feature, because it looks like every other feature that has dependencies is also an optional feature.
Obviously this means that the tests only work if the feature is installed.