### PR TITLE
Fix python_requires minimum python version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setup(
         'ssh': ssh_deps,
         'zst': zst_deps,
     },
-    python_requires=">=3.6,<4.0",
+    python_requires=">=3.7,<4.0",
 
     test_suite="smart_open.tests",
 


### PR DESCRIPTION
#### Motivation
This PR addresses an issue in `setup.py` where `python_requires` was not updated when python 3.7 was made the required minimum in #688.

- Fixes #806
