### PR TITLE
Add `__next__` method to FileLikeProxy

### DIFF
--- a/smart_open/utils.py
+++ b/smart_open/utils.py
@@ -215,6 +215,9 @@ class FileLikeProxy(wrapt.ObjectProxy):
     def __exit__(self, *args, **kwargs):
         """Exit inner after exiting outer."""
         try:
-            super().__exit__(*args, **kwargs)
+            return super().__exit__(*args, **kwargs)
         finally:
             self.__inner.__exit__(*args, **kwargs)
+
+    def __next__(self):
+        return self.__wrapped__.__next__()


### PR DESCRIPTION
#### Title

Add `__next__` method to FileLikeProxy

#### Motivation

Fix https://github.com/piskvorky/smart_open/issues/810

#### Tests

#### Work in progress

#### Checklist

- [x] Picked a concise, informative and complete title
- [x] Clearly explained the motivation behind the PR
- [x] Linked to any existing issues that your PR will be solving
- [x] Included tests for any new functionality
- [x] Checked that all unit tests pass

#### Workflow
