### PR TITLE
test_smart_open: close gzip obj after writing

### DIFF
--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -1441,7 +1441,8 @@ def gzip_compress(data, filename=None):
     buf = io.BytesIO()
     buf.name = filename
     with mock.patch('time.time', _MOCK_TIME):
-        gzip.GzipFile(fileobj=buf, mode='w').write(data)
+        with gzip.GzipFile(fileobj=buf, mode='w') as gz:
+            gz.write(data)
     return buf.getvalue()
 
 


### PR DESCRIPTION
#### Motivation

fixes test_smart_open unit tests when run under python 3.12.

https://hydra.nixos.org/build/257823750
[log](https://cache.nixos.org/log/9adz8h6d201x5cc2blgg9r97w2d414xx-python3.12-smart-open-7.0.4.drv)
```
=========================== short test summary info ============================
FAILED smart_open/tests/test_smart_open.py::SmartOpenHttpTest::test_http_gz - EOFError: Compressed file ended before the end-of-stream marker was reached
FAILED smart_open/tests/test_smart_open.py::SmartOpenHttpTest::test_http_gz_query - EOFError: Compressed file ended before the end-of-stream marker was reached
FAILED smart_open/tests/test_smart_open.py::test_s3_gzip_compress_sanity - EOFError: Compressed file ended before the end-of-stream marker was reached
FAILED smart_open/tests/test_smart_open.py::test_s3_read_explicit[s3://bucket/gzipped-.gz] - EOFError: Compressed file ended before the end-of-stream marker was reached
FAILED smart_open/tests/test_smart_open.py::test_s3_write_explicit[.gz-\x1f\x8b\x08\x087'\x93`\x02\xffkey\x00] - assert b"\x1f\x8b\x0...3\x00\x00\x00" == b"\x1f\x8b\x0...02\xffkey\x00"
FAILED smart_open/tests/test_smart_open.py::test_s3_write_implicit[s3://bucket/key.gz-.gz-\x1f\x8b\x08\x087'\x93`\x02\xffkey\x00] - assert b"\x1f\x8b\x0...3\x00\x00\x00" == b"\x1f\x8b\x0...02\xffkey\x00"
FAILED smart_open/tests/test_smart_open.py::test_s3_disable_compression[s3://bucket/key.gz-.gz-\x1f\x8b\x08\x087'\x93`\x02\xffkey\x00] - assert b"\x1f\x8b\x0...3\x00\x00\x00" == b"\x1f\x8b\x0...02\xffkey\x00"
= 7 failed, 372 passed, 4 skipped, 4 deselected, 4 xfailed, 2 xpassed, 2412 warnings in 93.89s (0:01:33) =
```
