### PR TITLE
Updates readline logic for azure to match s3

### DIFF
--- a/smart_open/tests/test_azure.py
+++ b/smart_open/tests/test_azure.py
@@ -373,6 +373,24 @@ class ReaderTest(unittest.TestCase):
         self.assertEqual(content[6:14], fin.read(8))  # ř is 2 bytes
         self.assertEqual(content[14:], fin.read())  # read the rest
 
+    def test_readline(self):
+        """Are Azure Blob Storage files read correctly with readlines?"""
+        content = u"hello wořld\nhow are you?".encode('utf8')
+        blob_name = "test_read_%s" % BLOB_NAME
+        put_to_container(blob_name, contents=content)
+        logger.debug('content: %r len: %r', content, len(content))
+
+        with smart_open.azure.Reader(CONTAINER_NAME, blob_name, CLIENT) as fin:
+            line = fin.readline()
+            self.assertEqual(line, 'hello wořld\n')
+
+            fin.seek(0)
+            actual = list(fin)
+            self.assertEqual(fin.tell(), len(content))
+
+        expected = ['hello wořld\n', 'how are you?']
+        self.assertEqual(expected, actual)
+
     def test_read_max_concurrency(self):
         """Are Azure Blob Storage files read correctly?"""
         content = u"hello wořld\nhow are you?".encode('utf8')

--- a/smart_open/tests/test_azure.py
+++ b/smart_open/tests/test_azure.py
@@ -373,24 +373,6 @@ class ReaderTest(unittest.TestCase):
         self.assertEqual(content[6:14], fin.read(8))  # ř is 2 bytes
         self.assertEqual(content[14:], fin.read())  # read the rest
 
-    def test_readline(self):
-        """Are Azure Blob Storage files read correctly with readlines?"""
-        content = u"hello wořld\nhow are you?".encode('utf8')
-        blob_name = "test_read_%s" % BLOB_NAME
-        put_to_container(blob_name, contents=content)
-        logger.debug('content: %r len: %r', content, len(content))
-
-        with smart_open.azure.Reader(CONTAINER_NAME, blob_name, CLIENT) as fin:
-            line = fin.readline()
-            self.assertEqual(line, 'hello wořld\n')
-
-            fin.seek(0)
-            actual = list(fin)
-            self.assertEqual(fin.tell(), len(content))
-
-        expected = ['hello wořld\n', 'how are you?']
-        self.assertEqual(expected, actual)
-
     def test_read_max_concurrency(self):
         """Are Azure Blob Storage files read correctly?"""
         content = u"hello wořld\nhow are you?".encode('utf8')


### PR DESCRIPTION
#### Title

Updates readline buffer management for azure, improving performance.

#### Motivation

Observed slow read times when iterating using `readlines()` from a 100MB csv file in Azure Blob Storage. Simple copies and reads were fine, slowness only observed with some code that was explicitly calling `readlines()`.

Borrows from the logic found in the S3 implementation, which was updated to be more efficient and does not perform as many scans on the local chunk of the remote file.

#### Tests

Confirmed clean run with `pytest -k test_azure`

#### Checklist

Before you create the PR, please make sure you have:

- [x] Picked a concise, informative and complete title
- [x] Clearly explained the motivation behind the PR
- [x] Linked to any existing issues that your PR will be solving
- [x] Included tests for any new functionality
- [x] Checked that all unit tests pass

#### Workflow

Please avoid rebasing and force-pushing to the branch of the PR once a review is in progress.
Rebasing can make your commits look a bit cleaner, but it also makes life more difficult from the reviewer, because they are no longer able to distinguish between code that has already been reviewed, and unreviewed code.
