### PR TITLE
Not able to upload a compressed S3 file using close()

### DIFF
--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -634,6 +634,43 @@ class MultipartWriterTest(unittest.TestCase):
 
             assert actual == contents
 
+    def test_write_gz_using_context_manager(self):
+        """Does s3 multipart upload create a compressed file using context manager?"""
+        contents = b'get ready for a surprise'
+        with smart_open.open(
+                f's3://{BUCKET_NAME}/{WRITE_KEY_NAME}.gz',
+                mode="wb",
+                transport_params={
+                    "multipart_upload": True,
+                    "min_part_size": 10,
+                }
+        ) as fout:
+            fout.write(contents)
+
+        with smart_open.open(f's3://{BUCKET_NAME}/{WRITE_KEY_NAME}.gz', 'rb') as fin:
+            actual = fin.read()
+
+        assert actual == contents
+
+    def test_write_gz_not_using_context_manager(self):
+        """Does s3 multipart upload create a compressed file not using context manager but close()?"""
+        contents = b'get ready for a surprise'
+        fout = smart_open.open(
+            f's3://{BUCKET_NAME}/{WRITE_KEY_NAME}.gz',
+            mode="wb",
+            transport_params={
+                "multipart_upload": True,
+                "min_part_size": 10,
+            }
+        )
+        fout.write(contents)
+        fout.close()
+
+        with smart_open.open(f's3://{BUCKET_NAME}/{WRITE_KEY_NAME}.gz', 'rb') as fin:
+            actual = fin.read()
+
+        assert actual == contents
+
     def test_write_gz_with_error(self):
         """Does s3 multipart upload abort for a failed compressed file upload?"""
         with self.assertRaises(ValueError):

--- a/smart_open/utils.py
+++ b/smart_open/utils.py
@@ -226,7 +226,7 @@ class FileLikeProxy(wrapt.ObjectProxy):
 
     def close(self):
         try:
-            self.__wrapped__.close()
+            return self.__wrapped__.close()
         finally:
             if self.__inner != self.__wrapped__:  # Don't close again if inner and wrapped are the same
                 self.__inner.close()

--- a/smart_open/utils.py
+++ b/smart_open/utils.py
@@ -223,3 +223,10 @@ class FileLikeProxy(wrapt.ObjectProxy):
 
     def __next__(self):
         return self.__wrapped__.__next__()
+
+    def close(self):
+        try:
+            self.__wrapped__.close()
+        finally:
+            if self.__inner != self.__wrapped__:  # Don't close again if inner and wrapped are the same
+                self.__inner.close()


### PR DESCRIPTION
#### Title: Not able to upload a compressed S3 file using close()

#### Motivation

We are using smart_open to compress and upload files to s3 without a context manager but since version 7.0.0 the following scenario is NOT longer working because we are using `close()` call without a context manager:
e.g.

```python
hook = S3Hook()
s3_params = {
    'client': hook.get_session().client('s3'),
}
f = smart_open.open('s3://bucket/file.gz', 'w', transport_params=s3_params)
f.write('Some content')
f.close()
```

The problem is that the close() call is only hitting the outer stream and NOT the inner stream. More information can be found in the [issue](https://github.com/piskvorky/smart_open/issues/837) information.

```
- Fixes #837
```

#### Tests

2 unit tests were added to shows how this change address the compressed file upload during the close() call.
#### Checklist

Before you create the PR, please make sure you have:

- [ x ] Picked a concise, informative and complete title
- [ x ] Clearly explained the motivation behind the PR
- [ x ] Linked to any existing issues that your PR will be solving
- [ x ] Included tests for any new functionality
- [ x ] Checked that all unit tests pass
