### PR TITLE
Ensure name attribute in ftp.py

### DIFF
--- a/integration-tests/test_ftp.py
+++ b/integration-tests/test_ftp.py
@@ -52,6 +52,26 @@ def test_binary(server_info):
         read_contents = f.read()
         assert read_contents == file_contents + appended_content1
 
+def test_compression(server_info):
+    server_type = server_info[0]
+    port_num = server_info[1]
+    file_contents = "Test Test \n new test \n another tests"
+    appended_content1 = "Added \n to end"
+
+    with open(f"{server_type}://user:123@localhost:{port_num}/file.gz", "w") as f:
+        f.write(file_contents)
+
+    with open(f"{server_type}://user:123@localhost:{port_num}/file.gz", "r") as f:
+        read_contents = f.read()
+        assert read_contents == file_contents
+
+    with open(f"{server_type}://user:123@localhost:{port_num}/file.gz", "a") as f:
+        f.write(appended_content1)
+
+    with open(f"{server_type}://user:123@localhost:{port_num}/file.gz", "r") as f:
+        read_contents = f.read()
+        assert read_contents == file_contents + appended_content1
+
 def test_line_endings_non_binary(server_info):
     server_type = server_info[0]
     port_num = server_info[1]

--- a/smart_open/ftp.py
+++ b/smart_open/ftp.py
@@ -169,4 +169,5 @@ def open(
     fobj.socket = socket
     fobj.conn = conn
     fobj.close = types.MethodType(full_close, fobj)
+    fobj.name = path
     return fobj

--- a/smart_open/ftp.py
+++ b/smart_open/ftp.py
@@ -169,5 +169,5 @@ def open(
     fobj.socket = socket
     fobj.conn = conn
     fobj.close = types.MethodType(full_close, fobj)
-    fobj.name = path
+    # fobj.name = path
     return fobj

--- a/smart_open/ftp.py
+++ b/smart_open/ftp.py
@@ -169,5 +169,4 @@ def open(
     fobj.socket = socket
     fobj.conn = conn
     fobj.close = types.MethodType(full_close, fobj)
-    # fobj.name = path
     return fobj

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -222,6 +222,7 @@ def open(
         raise NotImplementedError(ve.args[0])
 
     binary = _open_binary_stream(uri, binary_mode, transport_params)
+    assert hasattr(binary, "name"), "missing 'name' attr (for INFER_FROM_EXTENSION)"
     decompressed = so_compression.compression_wrapper(binary, binary_mode, compression)
 
     if 'b' not in mode or explicit_encoding is not None:

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -222,7 +222,8 @@ def open(
         raise NotImplementedError(ve.args[0])
 
     binary = _open_binary_stream(uri, binary_mode, transport_params)
-    assert hasattr(binary, "name"), "missing 'name' attr (for INFER_FROM_EXTENSION)"
+    assert hasattr(binary, "name"), "missing name attr (for INFER_FROM_EXTENSION)"
+    assert isinstance(binary.name, (str, bytes)), "name attr should be string-like"
     decompressed = so_compression.compression_wrapper(binary, binary_mode, compression)
 
     if 'b' not in mode or explicit_encoding is not None:

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -222,7 +222,7 @@ def open(
         raise NotImplementedError(ve.args[0])
 
     binary = _open_binary_stream(uri, binary_mode, transport_params)
-    assert hasattr(binary, "name"), "missing 'name' attr (for INFER_FROM_EXTENSION)"
+    # assert hasattr(binary, "name"), "missing 'name' attr (for INFER_FROM_EXTENSION)"
     decompressed = so_compression.compression_wrapper(binary, binary_mode, compression)
 
     if 'b' not in mode or explicit_encoding is not None:

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -222,7 +222,7 @@ def open(
         raise NotImplementedError(ve.args[0])
 
     binary = _open_binary_stream(uri, binary_mode, transport_params)
-    # assert hasattr(binary, "name"), "missing 'name' attr (for INFER_FROM_EXTENSION)"
+    assert hasattr(binary, "name"), "missing 'name' attr (for INFER_FROM_EXTENSION)"
     decompressed = so_compression.compression_wrapper(binary, binary_mode, compression)
 
     if 'b' not in mode or explicit_encoding is not None:


### PR DESCRIPTION
Alternative to https://github.com/piskvorky/smart_open/pull/842

#### Title

Please **pick a concise, informative and complete title** for your PR.
The title is important because it will appear in [our change log](https://github.com/RaRe-Technologies/smart_open/blob/master/CHANGELOG.md).

#### Motivation

Please explain the motivation behind this PR in the description.

If you're fixing a bug, link to the issue number like so:

Fixes #841 

If you're adding a new feature, then consider opening a ticket and discussing it with the maintainers before you actually do the hard work.

#### Tests

If you're fixing a bug, consider [test-driven development](https://en.wikipedia.org/wiki/Test-driven_development):

1. Create a unit test that demonstrates the bug. The test should **fail**.
2. Implement your bug fix.
3. The test you created should now **pass**.

If you're implementing a new feature, include unit tests for it.

Make sure all existing unit tests pass.
You can run them locally using:

    pytest smart_open

If there are any failures, please fix them before creating the PR (or mark it as WIP, see below).

#### Work in progress

If you're still working on your PR, include "WIP" in the title.
We'll skip reviewing it for the time being.
Once you're ready to review, remove the "WIP" from the title, and ping one of the maintainers (e.g. mpenkov).

#### Checklist

Before you create the PR, please make sure you have:

- [x] Picked a concise, informative and complete title
- [x] Clearly explained the motivation behind the PR
- [x] Linked to any existing issues that your PR will be solving
- [x] Included tests for any new functionality
- [ ] Checked that all unit tests pass

#### Workflow

Please avoid rebasing and force-pushing to the branch of the PR once a review is in progress.
Rebasing can make your commits look a bit cleaner, but it also makes life more difficult from the reviewer, because they are no longer able to distinguish between code that has already been reviewed, and unreviewed code.
