### PR TITLE
Add support for prefetching to sftp transport

### DIFF
--- a/smart_open/ssh.py
+++ b/smart_open/ssh.py
@@ -111,21 +111,18 @@ def parse_uri(uri_as_string):
 
 
 def open_uri(uri, mode, transport_params):
-    # `connect_kwargs` is a legitimate param *only* for sftp, so this filters it out of validation
-    #   (otherwise every call with this present complains it's not valid)
-    params_to_validate = {k: v for k, v in transport_params.items() if k != 'connect_kwargs'}
-    smart_open.utils.check_kwargs(open, params_to_validate)
+    kwargs = smart_open.utils.check_kwargs(open, transport_params)
     parsed_uri = parse_uri(uri)
     uri_path = parsed_uri.pop('uri_path')
     parsed_uri.pop('scheme')
-    return open(uri_path, mode, transport_params=transport_params, **parsed_uri)
+    return open(uri_path, mode, **parsed_uri, **kwargs)
 
 
-def _connect_ssh(hostname, username, port, password, transport_params):
+def _connect_ssh(hostname, username, port, password, connect_kwargs):
     ssh = paramiko.SSHClient()
     ssh.load_system_host_keys()
     ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-    kwargs = transport_params.get('connect_kwargs', {}).copy()
+    kwargs = (connect_kwargs or {}).copy()
     if 'key_filename' not in kwargs:
         kwargs.setdefault('password', password)
     kwargs.setdefault('username', username)
@@ -133,17 +130,13 @@ def _connect_ssh(hostname, username, port, password, transport_params):
     return ssh
 
 
-def _maybe_fetch_config(host, username=None, password=None, port=None, transport_params=None):
+def _maybe_fetch_config(host, username=None, password=None, port=None, connect_kwargs=None):
     # If all fields are set, return as-is.
-    if not any(arg is None for arg in (host, username, password, port, transport_params)):
-        return host, username, password, port, transport_params
+    if not any(arg is None for arg in (host, username, password, port, connect_kwargs)):
+        return host, username, password, port, connect_kwargs
 
     if not host:
         raise ValueError('you must specify the host to connect to')
-    if not transport_params:
-        transport_params = {}
-    if "connect_kwargs" not in transport_params:
-        transport_params["connect_kwargs"] = {}
 
     # Attempt to load an OpenSSH config.
     #
@@ -160,7 +153,7 @@ def _maybe_fetch_config(host, username=None, password=None, port=None, transport
     # - compression selection
     # - GSS configuration
     #
-    connect_params = transport_params["connect_kwargs"]
+    connect_params = (connect_kwargs or {}).copy()
     config_files = [f for f in _SSH_CONFIG_FILES if os.path.exists(f)]
     #
     # This is the actual name of the host.  The input host may actually be an
@@ -221,10 +214,10 @@ def _maybe_fetch_config(host, username=None, password=None, port=None, transport
     if actual_hostname:
         host = actual_hostname
 
-    return host, username, password, port, transport_params
+    return host, username, password, port, connect_params
 
 
-def open(path, mode='r', host=None, user=None, password=None, port=None, transport_params=None):
+def open(path, mode='r', host=None, user=None, password=None, port=None, connect_kwargs=None):
     """Open a file on a remote machine over SSH.
 
     Expects authentication to be already set up via existing keys on the local machine.
@@ -244,8 +237,8 @@ def open(path, mode='r', host=None, user=None, password=None, port=None, transpo
         The password to use to login to the remote machine.
     port: int, optional
         The port to connect to.
-    transport_params: dict, optional
-        Any additional settings to be passed to paramiko.SSHClient.connect
+    connect_kwargs: dict, optional
+        Any additional settings to be passed to paramiko.SSHClient.connect.
 
     Returns
     -------
@@ -259,8 +252,8 @@ def open(path, mode='r', host=None, user=None, password=None, port=None, transpo
     If ``username`` or ``password`` are specified in *both* the uri and
     ``transport_params``, ``transport_params`` will take precedence
     """
-    host, user, password, port, transport_params = _maybe_fetch_config(
-        host, user, password, port, transport_params
+    host, user, password, port, connect_kwargs = _maybe_fetch_config(
+        host, user, password, port, connect_kwargs
     )
 
     key = (host, user)
@@ -273,9 +266,9 @@ def open(path, mode='r', host=None, user=None, password=None, port=None, transpo
             #   and if not, refresh the connection
             if not ssh.get_transport().active:
                 ssh.close()
-                ssh = _SSH[key] = _connect_ssh(host, user, port, password, transport_params)
+                ssh = _SSH[key] = _connect_ssh(host, user, port, password, connect_kwargs)
         except KeyError:
-            ssh = _SSH[key] = _connect_ssh(host, user, port, password, transport_params)
+            ssh = _SSH[key] = _connect_ssh(host, user, port, password, connect_kwargs)
 
         try:
             transport = ssh.get_transport()

--- a/smart_open/ssh.py
+++ b/smart_open/ssh.py
@@ -217,7 +217,16 @@ def _maybe_fetch_config(host, username=None, password=None, port=None, connect_k
     return host, username, password, port, connect_params
 
 
-def open(path, mode='r', host=None, user=None, password=None, port=None, connect_kwargs=None):
+def open(
+    path,
+    mode="r",
+    host=None,
+    user=None,
+    password=None,
+    port=None,
+    connect_kwargs=None,
+    prefetch_kwargs=None,
+):
     """Open a file on a remote machine over SSH.
 
     Expects authentication to be already set up via existing keys on the local machine.
@@ -239,6 +248,9 @@ def open(path, mode='r', host=None, user=None, password=None, port=None, connect
         The port to connect to.
     connect_kwargs: dict, optional
         Any additional settings to be passed to paramiko.SSHClient.connect.
+    prefetch_kwargs: dict, optional
+        Any additional settings to be passed to paramiko.SFTPFile.prefetch.
+        The presence of this dict (even if empty) triggers prefetching.
 
     Returns
     -------
@@ -287,4 +299,6 @@ def open(path, mode='r', host=None, user=None, password=None, port=None, connect
 
     fobj = sftp_client.open(path, mode)
     fobj.name = path
+    if prefetch_kwargs is not None:
+        fobj.prefetch(**prefetch_kwargs)
     return fobj

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -474,7 +474,6 @@ class SmartOpenHttpTest(unittest.TestCase):
             user='ubuntu',
             password='pass',
             port=1022,
-            transport_params={'hello': 'world'},
         )
 
     @responses.activate

--- a/smart_open/tests/test_ssh.py
+++ b/smart_open/tests/test_ssh.py
@@ -127,6 +127,23 @@ class SSHOpen(unittest.TestCase):
             gss_trust_dns=False,
         )
 
+    @mock_ssh
+    def test_open_with_prefetch(self, mock_connect, get_transp_mock):
+        smart_open.open(
+            "ssh://user:pass@some-host/",
+            transport_params={"prefetch_kwargs": {"max_concurrent_requests": 3}},
+        )
+        mock_sftp = get_transp_mock().open_sftp_client()
+        mock_fobj = mock_sftp.open()
+        mock_fobj.prefetch.assert_called_with(max_concurrent_requests=3)
+
+    @mock_ssh
+    def test_open_without_prefetch(self, mock_connect, get_transp_mock):
+        smart_open.open("ssh://user:pass@some-host/")
+        mock_sftp = get_transp_mock().open_sftp_client()
+        mock_fobj = mock_sftp.open()
+        mock_fobj.prefetch.assert_not_called()
+
 
 if __name__ == "__main__":
     logging.basicConfig(format="%(asctime)s : %(levelname)s : %(message)s", level=logging.DEBUG)


### PR DESCRIPTION
#### Title

Add support for prefetching to sftp transport

#### Motivation

Add optional `prefetch_kwargs` to ssh transport_params

These may be used to trigger prefetching, which can drastically improve throughput if downloading an entire file over sftp

- Fixes #848

#### Checklist

Before you create the PR, please make sure you have:

- [x] Picked a concise, informative and complete title
- [x] Clearly explained the motivation behind the PR
- [x] Linked to any existing issues that your PR will be solving
- [x] Included tests for any new functionality
- [x] Checked that all unit tests pass

