### PR TITLE
build: fix invalid `fallback_version` when builing with `uv`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Tests should pass:
 pytest
 ```
 
-Thats it! When you're done, deactivate the venv:
+That's it! When you're done, deactivate the venv:
 
 ```sh
 deactivate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=64", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
-fallback_version = "0.1.dev1+gitnotfound"
+fallback_version = "0.1.dev0+gitnotfound"
 
 [project]
 name = "smart_open"


### PR DESCRIPTION
### Motivation

On the current version of the `develop` branch, the following setup doesn't work:

```bash
pip install uv
uv venv
uv pip install -e '.[test]'
```

That sequence (nominal uv usage) should work, but doesn't. The error message is:

```
 ValueError: choosing custom numbers for the `.devX` distance is not supported.
       The 0.1.dev1 can't be bumped
      Please drop the tag or create a new supported one ending in .dev0
```

In order to allow using the modern `uv` tool, this PR makes a very very tiny change to allow it to build again.
